### PR TITLE
Updated google protobuf dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>2.6.1</version>
+            <version>3.0.2</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
From version 2.61. to 3.0.2. The old protobuf dependency was giving me this error

`Error Message: java.lang.NoSuchMethodError: com.google.protobuf.Descriptors$FileDescriptor.getSyntax()Lcom/google/protobuf/Descriptors$FileDescriptor$Syntax;`