### PR TITLE
java.properties - Comment for default value does not match value set by install

### DIFF
--- a/skel/java.properties
+++ b/skel/java.properties
@@ -18,6 +18,5 @@ gauge_jvm_args =
 gauge_custom_compile_dir =
 
 # specify the level at which the objects should be cleared
-# Possible values are suite, spec and scenario. Default value is suite.
+# Possible values are suite, spec and scenario. Default value is scenario.
 gauge_clear_state_level = scenario
-


### PR DESCRIPTION
Small change to make the comment relating to clear state level match the value set by the installer.