### PR TITLE
Explicitly declaring dependencies that were relied upon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <scope>test</scope>
+            <version>1.6.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <scope>test</scope>
             <version>1.6.6</version>
@@ -66,6 +72,11 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>21.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Fixes Issue #83 by explicitly declaring Guava as a dependency.  Also explicitly declaring powermock-core for good measure. These were discovered via `mvn dependency:analyze`.