### PR TITLE
Fix issues with long java classpath on Windows platform 

### DIFF
--- a/gauge-java.go
+++ b/gauge-java.go
@@ -309,9 +309,7 @@ func runJavaCommandAsync(cmdName string, args []string, classpath string) *exec.
 	cmd := exec.Command(cmdName, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	env := os.Environ()
-	env = append(env, fmt.Sprintf("CLASSPATH=%s", classpath))
-	cmd.Env = env
+	os.Setenv("CLASSPATH", classpath)
 	//TODO: move to logs
 	/*fmt.Println(cmd.Args)*/
 	var err error


### PR DESCRIPTION
Windows platform has limitation on Maximum Path Length (https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx)
This cause problem with starting Gauge execution in java projects with long classpath
To fix this issue we can set the CLASSPATH as an environment variable

This fix will resolve:
https://github.com/getgauge/gauge/issues/156
https://github.com/getgauge/gauge/issues/184
https://github.com/getgauge/Intellij-Plugin/issues/277
https://github.com/getgauge/Intellij-Plugin/issues/164
https://github.com/getgauge/Intellij-Plugin/issues/277


