### PR TITLE
custom parser can now be located in default package

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/execution/parameters/parsers/base/ParameterParsingChain.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/parameters/parsers/base/ParameterParsingChain.java
@@ -22,7 +22,6 @@ public class ParameterParsingChain implements ParameterParser {
                 .map(this::asCustomParameterParser)
                 .filter(Objects::nonNull)
                 .forEach(chain::add);
-        System.out.println("LOADING " + chain);
         chain.add(new TableParameterParser(new TableConverter()));
         chain.add(new EnumParameterParser());
         chain.add(new PrimitiveParameterParser(new PrimitivesConverter()));
@@ -33,7 +32,6 @@ public class ParameterParsingChain implements ParameterParser {
         try {
             return clazz.newInstance();
         } catch (InstantiationException | IllegalAccessException e) {
-            e.printStackTrace();
             // currently there seems to be no logging system used, so we cannot warn the user about an error
             return null;
         }

--- a/src/main/java/com/thoughtworks/gauge/execution/parameters/parsers/base/ParameterParsingChain.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/parameters/parsers/base/ParameterParsingChain.java
@@ -19,17 +19,13 @@ public class ParameterParsingChain implements ParameterParser {
 
     public ParameterParsingChain() {
         new Reflections().getSubTypesOf(CustomParameterParser.class).stream()
-                .filter(this::isNotGaugeParser)
                 .map(this::asCustomParameterParser)
                 .filter(Objects::nonNull)
                 .forEach(chain::add);
+        System.out.println("LOADING " + chain);
         chain.add(new TableParameterParser(new TableConverter()));
         chain.add(new EnumParameterParser());
         chain.add(new PrimitiveParameterParser(new PrimitivesConverter()));
-    }
-
-    private boolean isNotGaugeParser(Class<? extends ParameterParser> clazz) {
-        return !clazz.getPackage().getName().equals("com.thoughtworks.gauge.execution.parameters.parsers.types");
     }
 
     private @Nullable
@@ -37,6 +33,7 @@ public class ParameterParsingChain implements ParameterParser {
         try {
             return clazz.newInstance();
         } catch (InstantiationException | IllegalAccessException e) {
+            e.printStackTrace();
             // currently there seems to be no logging system used, so we cannot warn the user about an error
             return null;
         }


### PR DESCRIPTION
clean up to old artifacts to allow also custom parsers in default packages

addresses https://github.com/getgauge/gauge-java/issues/142