### PR TITLE
Use parsedStepText instead of actualStepText in StepDetails

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/execution/ExecutionInfoMapper.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/ExecutionInfoMapper.java
@@ -46,7 +46,7 @@ public class ExecutionInfoMapper {
 
     public StepDetails stepFrom(Messages.StepInfo currentStep) {
         if (currentStep.isInitialized()) {
-            return new StepDetails(currentStep.getStep().getActualStepText(), currentStep.getIsFailed(),
+            return new StepDetails(currentStep.getStep().getParsedStepText(), currentStep.getIsFailed(),
                     currentStep.getStackTrace(), currentStep.getErrorMessage());
         }
         return new StepDetails();

--- a/src/test/java/com/thoughtworks/gauge/execution/ExecutionInfoMapperTest.java
+++ b/src/test/java/com/thoughtworks/gauge/execution/ExecutionInfoMapperTest.java
@@ -55,7 +55,7 @@ public class ExecutionInfoMapperTest extends TestCase {
 
         StepDetails stepDetails = new ExecutionInfoMapper().stepFrom(stepInfo);
 
-        assertEquals(ACTUAL_STEP_TEXT, stepDetails.getText());
+        assertEquals(PARSED_STEP_TEXT, stepDetails.getText());
         assertEquals(STACK_TRACE, stepDetails.getStackTrace());
         assertEquals(ERROR_MESSAGE, stepDetails.getErrorMessage());
         assertTrue(stepDetails.getIsFailing());
@@ -134,6 +134,6 @@ public class ExecutionInfoMapperTest extends TestCase {
         assertTrue(currentStep.getIsFailing());
         assertEquals(STACK_TRACE, currentStep.getStackTrace());
         assertEquals(ERROR_MESSAGE, currentStep.getErrorMessage());
-        assertEquals(ACTUAL_STEP_TEXT, currentStep.getText());
+        assertEquals(PARSED_STEP_TEXT, currentStep.getText());
     }
 }


### PR DESCRIPTION
It's good to see which parameter value is used in the step when it wasn't defined directly in the spec.

Actual:
_Facebook user < username > logged-in from client < clientTypeName >_
Expected:
_Facebook user "Bob" logged-in from client "Facebook Web"_