### PR TITLE
Trim the package name before scanning

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/ClasspathHelper.java
+++ b/src/main/java/com/thoughtworks/gauge/ClasspathHelper.java
@@ -14,7 +14,7 @@ public class ClasspathHelper {
             Collection<URL> urls = new ArrayList<>();
             final List<String> packages = Arrays.asList(packagesToScan.split(","));
             for (String packageToScan : packages) {
-                urls.addAll(org.reflections.util.ClasspathHelper.forPackage(packageToScan));
+                urls.addAll(org.reflections.util.ClasspathHelper.forPackage(packageToScan.trim()));
             }
             return urls;
         }


### PR DESCRIPTION
This is to allow parsing of:

```bash
package_to_scan = com.package.one, com.package.two
```

Currently, it'll not work if package name has a leading/trailing space.