### PR TITLE
Write screenshot to file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install gauge on linux
         if: matrix.os != 'windows-latest'
         run: |
-          git clone --depth=1 --branch=plugin-grpc https://github.com/getgauge/gauge
+          git clone --depth=1 https://github.com/getgauge/gauge
           cd gauge
           go run build/make.go --verbose
           go run build/make.go --install --prefix=/tmp/
@@ -52,7 +52,7 @@ jobs:
       - name: Install gauge (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          git clone --depth=1 --branch=plugin-grpc https://github.com/getgauge/gauge
+          git clone --depth=1 https://github.com/getgauge/gauge
           cd gauge
           go run build/make.go --verbose
           go run build/make.go --install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install gauge on linux
         if: matrix.os != 'windows-latest'
         run: |
-          git clone https://github.com/getgauge/gauge
+          git clone --depth=1 --branch=plugin-grpc https://github.com/getgauge/gauge
           cd gauge
           go run build/make.go --verbose
           go run build/make.go --install --prefix=/tmp/
@@ -52,7 +52,7 @@ jobs:
       - name: Install gauge (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          git clone https://github.com/getgauge/gauge
+          git clone --depth=1 --branch=plugin-grpc https://github.com/getgauge/gauge
           cd gauge
           go run build/make.go --verbose
           go run build/make.go --install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,13 @@ jobs:
           go run build/make.go --install
           echo "::add-path::C:\Program Files\gauge\bin"
 
+      - name: Install html report
+          run: |
+            git clone --depth=1 https://github.com/getgauge/html-report
+            cd html-report
+            go run build/make.go
+            go run build/make.go --install
+
       - name: Install Gauge Java plugin from source
         if: matrix.os != 'windows-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,11 +59,11 @@ jobs:
           echo "::add-path::C:\Program Files\gauge\bin"
 
       - name: Install html report
-          run: |
-            git clone --depth=1 https://github.com/getgauge/html-report
-            cd html-report
-            go run build/make.go
-            go run build/make.go --install
+        run: |
+          git clone --depth=1 https://github.com/getgauge/html-report
+          cd html-report
+          go run build/make.go
+          go run build/make.go --install
 
       - name: Install Gauge Java plugin from source
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Clone gauge-tests
         run: |
-          git clone --depth=1 https://github.com/getgauge/gauge-tests
+          git clone --depth=1 --branch=fileBasedScreenshot https://github.com/getgauge/gauge-tests
 
       - name: Run FTs on linux
         if: matrix.os != 'windows-latest'

--- a/genproto.sh
+++ b/genproto.sh
@@ -15,8 +15,13 @@
 #!/bin/sh
 
 #Using protoc version 2.6.1
-cd gauge-proto
-protoc --java_out=../src/main/java/ spec.proto
-protoc --java_out=../src/main/java/ messages.proto
-protoc --java_out=../src/main/java/ api.proto
-protoc --java_out=../src/main/java/ lsp.proto
+for filename in gauge-proto/*.proto; do
+  newName="$filename-bkp"
+  sed 's/option java_package = "com.thoughtworks.gauge";/option java_package = "gauge.messages";/' "$filename" > "$newName"
+  rm "$filename"
+  cp "$newName" "$filename"
+  rm "$newName"
+done
+mvn protobuf:compile-custom protobuf:compile
+cp  target/generated-sources/protobuf/java/gauge/messages/*.java src/main/java/gauge/messages
+cp  target/generated-sources/protobuf/grpc-java/gauge/messages/*.java src/main/java/gauge/messages

--- a/pom.xml
+++ b/pom.xml
@@ -115,9 +115,11 @@
                     <pluginArtifact>
                         io.grpc:protoc-gen-grpc-java:1.13.1:exe:${os.detected.classifier}
                     </pluginArtifact>
+                    <protoSourceRoot>gauge-proto</protoSourceRoot>
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>none</phase>
                         <goals>
                             <goal>compile</goal>
                             <goal>compile-custom</goal>

--- a/src/main/java/com/thoughtworks/gauge/Gauge.java
+++ b/src/main/java/com/thoughtworks/gauge/Gauge.java
@@ -29,9 +29,9 @@ public class Gauge {
         }
     };
     private static ClassInstanceManager instanceManager;
-    private static ThreadLocal<List<byte[]>> screenshots = new InheritableThreadLocal<List<byte[]>>() {
+    private static ThreadLocal<List<String>> screenshots = new InheritableThreadLocal<List<String>>() {
         @Override
-        protected List<byte[]> initialValue() {
+        protected List<String> initialValue() {
             return new ArrayList<>();
         }
     };
@@ -61,11 +61,11 @@ public class Gauge {
     }
 
     public static void captureScreenshot() {
-        byte[] screenshotBytes = new ScreenshotFactory(instanceManager).getScreenshotBytes();
-        getScreenshots().add(screenshotBytes);
+        String screenshotFileName = new ScreenshotFactory(instanceManager).getScreenshotBytes();
+        getScreenshots().add(screenshotFileName);
     }
 
-    static List<byte[]> getScreenshots() {
+    static List<String> getScreenshots() {
         return screenshots.get();
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/GaugeConstant.java
+++ b/src/main/java/com/thoughtworks/gauge/GaugeConstant.java
@@ -23,5 +23,5 @@ public class GaugeConstant {
     public static final String GAUGE_PROJECT_ROOT = "GAUGE_PROJECT_ROOT";
     public static final String GAUGE_CUSTOM_COMPILE_DIR = "gauge_custom_compile_dir";
     public static final String DEFAULT_SRC_DIR = "src/test/java";
-    public static final String SCREENSHOTS_DIR = "screenshots_dir";
+    public static final String SCREENSHOTS_DIR_ENV = "screenshots_dir";
 }

--- a/src/main/java/com/thoughtworks/gauge/GaugeConstant.java
+++ b/src/main/java/com/thoughtworks/gauge/GaugeConstant.java
@@ -23,4 +23,5 @@ public class GaugeConstant {
     public static final String GAUGE_PROJECT_ROOT = "GAUGE_PROJECT_ROOT";
     public static final String GAUGE_CUSTOM_COMPILE_DIR = "gauge_custom_compile_dir";
     public static final String DEFAULT_SRC_DIR = "src/test/java";
+    public static final String SCREENSHOTS_DIR = "screenshots_dir";
 }

--- a/src/main/java/com/thoughtworks/gauge/LspServer.java
+++ b/src/main/java/com/thoughtworks/gauge/LspServer.java
@@ -41,12 +41,10 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void getStepNames(Messages.StepNamesRequest request, StreamObserver<Messages.StepNamesResponse> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.StepNamesRequest);
-        Messages.Message process = processor.process(new Messages.Message() {
-            @Override
-            public Messages.StepNamesRequest getStepNamesRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setStepNamesRequest(request);
+
+        Messages.Message process = processor.process(builder.build());
         responseObserver.onNext(process.getStepNamesResponse());
         responseObserver.onCompleted();
     }
@@ -54,12 +52,9 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void cacheFile(Messages.CacheFileRequest request, StreamObserver<Lsp.Empty> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.CacheFileRequest);
-        processor.process(new Messages.Message() {
-            @Override
-            public Messages.CacheFileRequest getCacheFileRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setCacheFileRequest(request);
+        processor.process(builder.build());
         responseObserver.onNext(Lsp.Empty.newBuilder().build());
         responseObserver.onCompleted();
     }
@@ -67,12 +62,9 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void getStepPositions(Messages.StepPositionsRequest request, StreamObserver<Messages.StepPositionsResponse> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.StepPositionsRequest);
-        Messages.Message process = processor.process(new Messages.Message() {
-            @Override
-            public Messages.StepPositionsRequest getStepPositionsRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setStepPositionsRequest(request);
+        Messages.Message process = processor.process(builder.build());
         responseObserver.onNext(process.getStepPositionsResponse());
         responseObserver.onCompleted();
     }
@@ -87,12 +79,9 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void implementStub(Messages.StubImplementationCodeRequest request, StreamObserver<Messages.FileDiff> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.StubImplementationCodeRequest);
-        Messages.Message process = processor.process(new Messages.Message() {
-            @Override
-            public Messages.StubImplementationCodeRequest getStubImplementationCodeRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setStubImplementationCodeRequest(request);
+        Messages.Message process = processor.process(builder.build());
         responseObserver.onNext(process.getFileDiff());
         responseObserver.onCompleted();
     }
@@ -100,12 +89,9 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void validateStep(Messages.StepValidateRequest request, StreamObserver<Messages.StepValidateResponse> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.StepValidateRequest);
-        Messages.Message process = processor.process(new Messages.Message() {
-            @Override
-            public Messages.StepValidateRequest getStepValidateRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setStepValidateRequest(request);
+        Messages.Message process = processor.process(builder.build());
         responseObserver.onNext(process.getStepValidateResponse());
         responseObserver.onCompleted();
     }
@@ -113,12 +99,9 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void refactor(Messages.RefactorRequest request, StreamObserver<Messages.RefactorResponse> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.RefactorRequest);
-        Messages.Message process = processor.process(new Messages.Message() {
-            @Override
-            public Messages.RefactorRequest getRefactorRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setRefactorRequest(request);
+        Messages.Message process = processor.process(builder.build());
         responseObserver.onNext(process.getRefactorResponse());
         responseObserver.onCompleted();
     }
@@ -126,12 +109,9 @@ public class LspServer extends lspServiceGrpc.lspServiceImplBase {
     @Override
     public void getStepName(Messages.StepNameRequest request, StreamObserver<Messages.StepNameResponse> responseObserver) {
         IMessageProcessor processor = messageDispatcher.getProcessor(Messages.Message.MessageType.StepNameRequest);
-        Messages.Message process = processor.process(new Messages.Message() {
-            @Override
-            public Messages.StepNameRequest getStepNameRequest() {
-                return request;
-            }
-        });
+        Messages.Message.Builder builder = Messages.Message.newBuilder();
+        builder.setStepNameRequest(request);
+        Messages.Message process = processor.process(builder.build());
         responseObserver.onNext(process.getStepNameResponse());
         responseObserver.onCompleted();
     }

--- a/src/main/java/com/thoughtworks/gauge/ScreenshotCollector.java
+++ b/src/main/java/com/thoughtworks/gauge/ScreenshotCollector.java
@@ -15,7 +15,6 @@
 
 package com.thoughtworks.gauge;
 
-import com.google.protobuf.ByteString;
 import gauge.messages.Spec;
 
 import java.util.ArrayList;
@@ -25,20 +24,18 @@ import static com.thoughtworks.gauge.Gauge.getScreenshots;
 
 public class ScreenshotCollector {
     public Spec.ProtoExecutionResult addPendingScreenshotTo(Spec.ProtoExecutionResult result) {
-        List<byte[]> screenshots = getAllPendingScreenshots();
+        ArrayList<String> screenshots = getAllPendingScreenshots();
         return addPendingScreenshot(result, screenshots);
     }
 
-    Spec.ProtoExecutionResult addPendingScreenshot(Spec.ProtoExecutionResult result, List<byte[]> screenshots) {
+    Spec.ProtoExecutionResult addPendingScreenshot(Spec.ProtoExecutionResult result, List<String> screenshotsFileName) {
         Spec.ProtoExecutionResult.Builder builder = Spec.ProtoExecutionResult.newBuilder(result);
-        for (byte[] screenshot : screenshots) {
-            builder.addScreenshots(ByteString.copyFrom(screenshot));
-        }
+        builder.addAllScreenshotFiles(screenshotsFileName);
         return builder.build();
     }
 
-    private List<byte[]> getAllPendingScreenshots() {
-        List<byte[]> pendingScreenshots = new ArrayList<>(getScreenshots());
+    private ArrayList<String> getAllPendingScreenshots() {
+        ArrayList<String> pendingScreenshots = new ArrayList<>(getScreenshots());
         clear();
         return pendingScreenshots;
     }

--- a/src/main/java/com/thoughtworks/gauge/execution/AbstractExecutionStage.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/AbstractExecutionStage.java
@@ -37,15 +37,13 @@ public abstract class AbstractExecutionStage implements ExecutionStage {
         if (previousStageResult.getFailed()) {
             builder.setErrorMessage(previousStageResult.getErrorMessage());
             builder.setErrorType(previousStageResult.getErrorType());
-            builder.setScreenShot(previousStageResult.getScreenShot());
-            builder.setFailureScreenshot(previousStageResult.getFailureScreenshot());
+            builder.setFailureScreenshotFile(previousStageResult.getFailureScreenshotFile());
             builder.setStackTrace(previousStageResult.getStackTrace());
             builder.setRecoverableError(previousStageResult.getRecoverableError());
         } else if (execResult.getFailed()) {
             builder.setErrorType(execResult.getErrorType());
             builder.setErrorMessage(execResult.getErrorMessage());
-            builder.setScreenShot(execResult.getScreenShot());
-            builder.setFailureScreenshot(execResult.getFailureScreenshot());
+            builder.setFailureScreenshotFile(execResult.getFailureScreenshotFile());
             builder.setStackTrace(execResult.getStackTrace());
             builder.setRecoverableError(execResult.getRecoverableError());
         }

--- a/src/main/java/com/thoughtworks/gauge/execution/MethodExecutor.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/MethodExecutor.java
@@ -15,7 +15,6 @@
 
 package com.thoughtworks.gauge.execution;
 
-import com.google.protobuf.ByteString;
 import com.thoughtworks.gauge.ClassInstanceManager;
 import com.thoughtworks.gauge.ContinueOnFailure;
 import com.thoughtworks.gauge.screenshot.ScreenshotFactory;
@@ -51,9 +50,8 @@ public class MethodExecutor {
 
     private Spec.ProtoExecutionResult createFailureExecResult(long execTime, Throwable e, boolean recoverable, Class[] continuableExceptions) {
         Spec.ProtoExecutionResult.Builder builder = Spec.ProtoExecutionResult.newBuilder().setFailed(true);
-        ByteString screenshotBytes = ByteString.copyFrom(new ScreenshotFactory(instanceManager).getScreenshotBytes());
-        builder.setScreenShot(screenshotBytes);
-        builder.setFailureScreenshot(screenshotBytes);
+        String screenshotFileName = new ScreenshotFactory(instanceManager).getScreenshotBytes();
+        builder.setFailureScreenshotFile(screenshotFileName);
         if (e.getCause() != null) {
             builder.setRecoverableError(false);
             for (Class c : continuableExceptions) {

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshot.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshot.java
@@ -1,3 +1,17 @@
+// Copyright 2019 ThoughtWorks, Inc.
+
+// This file is part of Gauge-Java.
+
+// This program is free software.
+//
+// It is dual-licensed under:
+// 1) the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version;
+// or
+// 2) the Eclipse Public License v1.0.
+//
+// You can redistribute it and/or modify it under the terms of either license.
+// We would then provide copied of each license in a separate .txt file with the name of the license as the title of the file.
 package com.thoughtworks.gauge.screenshot;
 
 interface CustomScreenshot {

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshot.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshot.java
@@ -1,4 +1,4 @@
 package com.thoughtworks.gauge.screenshot;
 
-public interface ICustomScreenshot {
+interface CustomScreenshot {
 }

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotScanner.java
@@ -34,10 +34,10 @@ public class CustomScreenshotScanner implements IScanner {
             ScreenshotFactory.setCustomScreenshotGrabber(customScreenGrabber);
         }
 
-        Set<Class<? extends ICustomScreenshotWriter>> customScreenshotWriters = reflections.getSubTypesOf(ICustomScreenshotWriter.class);
+        Set<Class<? extends CustomScreenshotWriter>> customScreenshotWriters = reflections.getSubTypesOf(CustomScreenshotWriter.class);
 
         if (customScreenshotWriters.size() > 0) {
-            Class<? extends ICustomScreenshotWriter> customScreenWriter = customScreenshotWriters.iterator().next();
+            Class<? extends CustomScreenshotWriter> customScreenWriter = customScreenshotWriters.iterator().next();
             Logger.debug(String.format("Using %s as custom screenshot grabber", customScreenWriter.getName()));
             ScreenshotFactory.setCustomScreenshotGrabber(customScreenWriter);
         }

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotScanner.java
@@ -27,10 +27,19 @@ import java.util.Set;
 public class CustomScreenshotScanner implements IScanner {
     public void scan(Reflections reflections) {
         Set<Class<? extends ICustomScreenshotGrabber>> customScreenshotGrabbers = reflections.getSubTypesOf(ICustomScreenshotGrabber.class);
+
         if (customScreenshotGrabbers.size() > 0) {
             Class<? extends ICustomScreenshotGrabber> customScreenGrabber = customScreenshotGrabbers.iterator().next();
             Logger.debug(String.format("Using %s as custom screenshot grabber", customScreenGrabber.getName()));
             ScreenshotFactory.setCustomScreenshotGrabber(customScreenGrabber);
+        }
+
+        Set<Class<? extends ICustomScreenshotWriter>> customScreenshotWriters = reflections.getSubTypesOf(ICustomScreenshotWriter.class);
+
+        if (customScreenshotWriters.size() > 0) {
+            Class<? extends ICustomScreenshotWriter> customScreenWriter = customScreenshotWriters.iterator().next();
+            Logger.debug(String.format("Using %s as custom screenshot grabber", customScreenWriter.getName()));
+            ScreenshotFactory.setCustomScreenshotGrabber(customScreenWriter);
         }
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotWriter.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotWriter.java
@@ -22,7 +22,7 @@ package com.thoughtworks.gauge.screenshot;
  * Implementation of this interface should capture screenshot and write them into a unique file
  * inside screenshots directory. Use "screenshots_dir" env to get screenshot directory path"
  */
-public interface ICustomScreenshotWriter extends ICustomScreenshot {
+public interface CustomScreenshotWriter extends CustomScreenshot {
 
     /**
      * @return Name of the screenshot file taken.

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotWriter.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotWriter.java
@@ -1,4 +1,4 @@
-// Copyright 2015 ThoughtWorks, Inc.
+// Copyright 2019 ThoughtWorks, Inc.
 
 // This file is part of Gauge-Java.
 

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshot.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshot.java
@@ -1,0 +1,4 @@
+package com.thoughtworks.gauge.screenshot;
+
+public interface ICustomScreenshot {
+}

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshotGrabber.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshotGrabber.java
@@ -20,6 +20,7 @@ package com.thoughtworks.gauge.screenshot;
  * The captured screenshots can be seen on the reports on failure.
  * If multiple implementations are found, one will be picked randomly to capture screenshots.
  */
+@Deprecated
 public interface ICustomScreenshotGrabber extends ICustomScreenshot {
 
 

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshotGrabber.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshotGrabber.java
@@ -21,7 +21,7 @@ package com.thoughtworks.gauge.screenshot;
  * If multiple implementations are found, one will be picked randomly to capture screenshots.
  */
 @Deprecated
-public interface ICustomScreenshotGrabber extends ICustomScreenshot {
+public interface ICustomScreenshotGrabber extends CustomScreenshot {
 
 
     /**

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshotWriter.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ICustomScreenshotWriter.java
@@ -19,14 +19,14 @@ package com.thoughtworks.gauge.screenshot;
  * Implement this interface to take Custom Screenshots on Failure. It overrides the default screenshot taking mechanism.
  * The captured screenshots can be seen on the reports on failure.
  * If multiple implementations are found, one will be picked randomly to capture screenshots.
+ * Implementation of this interface should capture screenshot and write them into a unique file
+ * inside screenshots directory. Use "screenshots_dir" env to get screenshot directory path"
  */
-public interface ICustomScreenshotGrabber extends ICustomScreenshot {
-
+public interface ICustomScreenshotWriter extends ICustomScreenshot {
 
     /**
-     * @return Byte array of the screenshot taken.
-     * Return an empty Byte array if unable to capture screen.
+     * @return Name of the screenshot file taken.
      */
-    byte[] takeScreenshot();
+    String takeScreenshot();
 
 }

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ScreenshotFactory.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ScreenshotFactory.java
@@ -79,7 +79,7 @@ public class ScreenshotFactory {
 
     private File generateUniqueScreenshotFile() {
         String fileName = String.format("screenshot-%s.%s", UUID.randomUUID().toString(), IMAGE_EXTENSION);
-        Path path = Paths.get(System.getenv(GaugeConstant.SCREENSHOTS_DIR), fileName);
+        Path path = Paths.get(System.getenv(GaugeConstant.SCREENSHOTS_DIR_ENV), fileName);
         return new File(path.toAbsolutePath().toString());
     }
 

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ScreenshotFactory.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ScreenshotFactory.java
@@ -37,14 +37,14 @@ import java.util.UUID;
 public class ScreenshotFactory {
 
     public static final String IMAGE_EXTENSION = "png";
-    private static Class<? extends ICustomScreenshot> customScreenshotGrabber;
+    private static Class<? extends CustomScreenshot> customScreenshotGrabber;
     private static ClassInstanceManager manager;
 
     public ScreenshotFactory(ClassInstanceManager manager) {
         this.manager = manager;
     }
 
-    static void setCustomScreenshotGrabber(Class<? extends ICustomScreenshot> customScreenGrabber) {
+    static void setCustomScreenshotGrabber(Class<? extends CustomScreenshot> customScreenGrabber) {
         customScreenshotGrabber = customScreenGrabber;
     }
 
@@ -58,9 +58,9 @@ public class ScreenshotFactory {
     private String takeScreenshot() {
         if (customScreenshotGrabber != null) {
             try {
-                ICustomScreenshot customScreenInstance = (ICustomScreenshot) manager.get(customScreenshotGrabber);
-                if (customScreenInstance instanceof ICustomScreenshotWriter) {
-                     return ((ICustomScreenshotWriter) customScreenInstance).takeScreenshot();
+                CustomScreenshot customScreenInstance = (CustomScreenshot) manager.get(customScreenshotGrabber);
+                if (customScreenInstance instanceof CustomScreenshotWriter) {
+                     return ((CustomScreenshotWriter) customScreenInstance).takeScreenshot();
                 } else {
                     byte[] bytes = ((ICustomScreenshotGrabber) customScreenInstance).takeScreenshot();
                     File file = generateUniqueScreenshotFile();

--- a/src/main/java/gauge/messages/Api.java
+++ b/src/main/java/gauge/messages/Api.java
@@ -26268,8 +26268,8 @@ public final class Api {
       "\020\022\031\n\025ExtractConceptRequest\020\021\022\032\n\026ExtractC" +
       "onceptResponse\020\022\022\026\n\022FormatSpecsRequest\020\023" +
       "\022\027\n\023FormatSpecsResponse\020\024\022!\n\035Unsupported" +
-      "ApiMessageResponse\020\025B\021\252\002\016Gauge.Messagesb" +
-      "\006proto3"
+      "ApiMessageResponse\020\025B!\n\016gauge.messages\252\002" +
+      "\016Gauge.Messagesb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/src/main/java/gauge/messages/Messages.java
+++ b/src/main/java/gauge/messages/Messages.java
@@ -439,14 +439,26 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the suite result after suite execution done.
+     * </pre>
+     *
      * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
      */
     boolean hasExecutionResult();
     /**
+     * <pre>
+     *&#47; Holds the suite result after suite execution done.
+     * </pre>
+     *
      * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
      */
     gauge.messages.Spec.ProtoExecutionResult getExecutionResult();
     /**
+     * <pre>
+     *&#47; Holds the suite result after suite execution done.
+     * </pre>
+     *
      * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
      */
     gauge.messages.Spec.ProtoExecutionResultOrBuilder getExecutionResultOrBuilder();
@@ -543,18 +555,30 @@ public final class Messages {
     public static final int EXECUTIONRESULT_FIELD_NUMBER = 1;
     private gauge.messages.Spec.ProtoExecutionResult executionResult_;
     /**
+     * <pre>
+     *&#47; Holds the suite result after suite execution done.
+     * </pre>
+     *
      * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
      */
     public boolean hasExecutionResult() {
       return executionResult_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the suite result after suite execution done.
+     * </pre>
+     *
      * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
      */
     public gauge.messages.Spec.ProtoExecutionResult getExecutionResult() {
       return executionResult_ == null ? gauge.messages.Spec.ProtoExecutionResult.getDefaultInstance() : executionResult_;
     }
     /**
+     * <pre>
+     *&#47; Holds the suite result after suite execution done.
+     * </pre>
+     *
      * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
      */
     public gauge.messages.Spec.ProtoExecutionResultOrBuilder getExecutionResultOrBuilder() {
@@ -886,12 +910,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Spec.ProtoExecutionResult, gauge.messages.Spec.ProtoExecutionResult.Builder, gauge.messages.Spec.ProtoExecutionResultOrBuilder> executionResultBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public boolean hasExecutionResult() {
         return executionResultBuilder_ != null || executionResult_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public gauge.messages.Spec.ProtoExecutionResult getExecutionResult() {
@@ -902,6 +934,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public Builder setExecutionResult(gauge.messages.Spec.ProtoExecutionResult value) {
@@ -918,6 +954,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public Builder setExecutionResult(
@@ -932,6 +972,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public Builder mergeExecutionResult(gauge.messages.Spec.ProtoExecutionResult value) {
@@ -950,6 +994,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public Builder clearExecutionResult() {
@@ -964,6 +1012,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public gauge.messages.Spec.ProtoExecutionResult.Builder getExecutionResultBuilder() {
@@ -972,6 +1024,10 @@ public final class Messages {
         return getExecutionResultFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       public gauge.messages.Spec.ProtoExecutionResultOrBuilder getExecutionResultOrBuilder() {
@@ -983,6 +1039,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the suite result after suite execution done.
+       * </pre>
+       *
        * <code>.gauge.messages.ProtoExecutionResult executionResult = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -1056,17 +1116,57 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    boolean hasSuiteResult();
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSuiteResult getSuiteResult();
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSuiteResultOrBuilder getSuiteResultOrBuilder();
   }
   /**
    * <pre>
@@ -1124,6 +1224,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoSuiteResult.Builder subBuilder = null;
+              if (suiteResult_ != null) {
+                subBuilder = suiteResult_.toBuilder();
+              }
+              suiteResult_ = input.readMessage(gauge.messages.Spec.ProtoSuiteResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(suiteResult_);
+                suiteResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -1159,22 +1272,70 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int SUITERESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoSuiteResult suiteResult_;
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    public boolean hasSuiteResult() {
+      return suiteResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSuiteResult getSuiteResult() {
+      return suiteResult_ == null ? gauge.messages.Spec.ProtoSuiteResult.getDefaultInstance() : suiteResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSuiteResultOrBuilder getSuiteResultOrBuilder() {
+      return getSuiteResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1194,6 +1355,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (suiteResult_ != null) {
+        output.writeMessage(2, getSuiteResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1206,6 +1370,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (suiteResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getSuiteResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1228,6 +1396,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasSuiteResult() == other.hasSuiteResult());
+      if (hasSuiteResult()) {
+        result = result && getSuiteResult()
+            .equals(other.getSuiteResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -1242,6 +1415,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasSuiteResult()) {
+        hash = (37 * hash) + SUITERESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getSuiteResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -1386,6 +1563,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (suiteResultBuilder_ == null) {
+          suiteResult_ = null;
+        } else {
+          suiteResult_ = null;
+          suiteResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -1416,6 +1599,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (suiteResultBuilder_ == null) {
+          result.suiteResult_ = suiteResult_;
+        } else {
+          result.suiteResult_ = suiteResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -1468,6 +1656,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasSuiteResult()) {
+          mergeSuiteResult(other.getSuiteResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -1501,12 +1692,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -1517,6 +1716,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -1533,6 +1736,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -1547,6 +1754,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -1565,6 +1776,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -1579,6 +1794,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -1587,6 +1806,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -1598,6 +1821,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -1612,6 +1839,168 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoSuiteResult suiteResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSuiteResult, gauge.messages.Spec.ProtoSuiteResult.Builder, gauge.messages.Spec.ProtoSuiteResultOrBuilder> suiteResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public boolean hasSuiteResult() {
+        return suiteResultBuilder_ != null || suiteResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSuiteResult getSuiteResult() {
+        if (suiteResultBuilder_ == null) {
+          return suiteResult_ == null ? gauge.messages.Spec.ProtoSuiteResult.getDefaultInstance() : suiteResult_;
+        } else {
+          return suiteResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder setSuiteResult(gauge.messages.Spec.ProtoSuiteResult value) {
+        if (suiteResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          suiteResult_ = value;
+          onChanged();
+        } else {
+          suiteResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder setSuiteResult(
+          gauge.messages.Spec.ProtoSuiteResult.Builder builderForValue) {
+        if (suiteResultBuilder_ == null) {
+          suiteResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          suiteResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder mergeSuiteResult(gauge.messages.Spec.ProtoSuiteResult value) {
+        if (suiteResultBuilder_ == null) {
+          if (suiteResult_ != null) {
+            suiteResult_ =
+              gauge.messages.Spec.ProtoSuiteResult.newBuilder(suiteResult_).mergeFrom(value).buildPartial();
+          } else {
+            suiteResult_ = value;
+          }
+          onChanged();
+        } else {
+          suiteResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder clearSuiteResult() {
+        if (suiteResultBuilder_ == null) {
+          suiteResult_ = null;
+          onChanged();
+        } else {
+          suiteResult_ = null;
+          suiteResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSuiteResult.Builder getSuiteResultBuilder() {
+        
+        onChanged();
+        return getSuiteResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSuiteResultOrBuilder getSuiteResultOrBuilder() {
+        if (suiteResultBuilder_ != null) {
+          return suiteResultBuilder_.getMessageOrBuilder();
+        } else {
+          return suiteResult_ == null ?
+              gauge.messages.Spec.ProtoSuiteResult.getDefaultInstance() : suiteResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSuiteResult, gauge.messages.Spec.ProtoSuiteResult.Builder, gauge.messages.Spec.ProtoSuiteResultOrBuilder> 
+          getSuiteResultFieldBuilder() {
+        if (suiteResultBuilder_ == null) {
+          suiteResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoSuiteResult, gauge.messages.Spec.ProtoSuiteResult.Builder, gauge.messages.Spec.ProtoSuiteResultOrBuilder>(
+                  getSuiteResult(),
+                  getParentForChildren(),
+                  isClean());
+          suiteResult_ = null;
+        }
+        return suiteResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -1671,17 +2060,54 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    boolean hasSuiteResult();
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSuiteResult getSuiteResult();
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSuiteResultOrBuilder getSuiteResultOrBuilder();
   }
   /**
    * <pre>
@@ -1739,6 +2165,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoSuiteResult.Builder subBuilder = null;
+              if (suiteResult_ != null) {
+                subBuilder = suiteResult_.toBuilder();
+              }
+              suiteResult_ = input.readMessage(gauge.messages.Spec.ProtoSuiteResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(suiteResult_);
+                suiteResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -1774,22 +2213,67 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current suite execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int SUITERESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoSuiteResult suiteResult_;
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    public boolean hasSuiteResult() {
+      return suiteResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSuiteResult getSuiteResult() {
+      return suiteResult_ == null ? gauge.messages.Spec.ProtoSuiteResult.getDefaultInstance() : suiteResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the suite result in execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSuiteResultOrBuilder getSuiteResultOrBuilder() {
+      return getSuiteResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1809,6 +2293,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (suiteResult_ != null) {
+        output.writeMessage(2, getSuiteResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1821,6 +2308,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (suiteResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getSuiteResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1843,6 +2334,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasSuiteResult() == other.hasSuiteResult());
+      if (hasSuiteResult()) {
+        result = result && getSuiteResult()
+            .equals(other.getSuiteResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -1857,6 +2353,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasSuiteResult()) {
+        hash = (37 * hash) + SUITERESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getSuiteResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2001,6 +2501,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (suiteResultBuilder_ == null) {
+          suiteResult_ = null;
+        } else {
+          suiteResult_ = null;
+          suiteResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -2031,6 +2537,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (suiteResultBuilder_ == null) {
+          result.suiteResult_ = suiteResult_;
+        } else {
+          result.suiteResult_ = suiteResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -2083,6 +2594,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasSuiteResult()) {
+          mergeSuiteResult(other.getSuiteResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -2116,12 +2630,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -2132,6 +2654,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -2148,6 +2674,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -2162,6 +2692,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -2180,6 +2714,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -2194,6 +2732,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -2202,6 +2744,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -2213,6 +2759,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current suite execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -2227,6 +2777,159 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoSuiteResult suiteResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSuiteResult, gauge.messages.Spec.ProtoSuiteResult.Builder, gauge.messages.Spec.ProtoSuiteResultOrBuilder> suiteResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public boolean hasSuiteResult() {
+        return suiteResultBuilder_ != null || suiteResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSuiteResult getSuiteResult() {
+        if (suiteResultBuilder_ == null) {
+          return suiteResult_ == null ? gauge.messages.Spec.ProtoSuiteResult.getDefaultInstance() : suiteResult_;
+        } else {
+          return suiteResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder setSuiteResult(gauge.messages.Spec.ProtoSuiteResult value) {
+        if (suiteResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          suiteResult_ = value;
+          onChanged();
+        } else {
+          suiteResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder setSuiteResult(
+          gauge.messages.Spec.ProtoSuiteResult.Builder builderForValue) {
+        if (suiteResultBuilder_ == null) {
+          suiteResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          suiteResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder mergeSuiteResult(gauge.messages.Spec.ProtoSuiteResult value) {
+        if (suiteResultBuilder_ == null) {
+          if (suiteResult_ != null) {
+            suiteResult_ =
+              gauge.messages.Spec.ProtoSuiteResult.newBuilder(suiteResult_).mergeFrom(value).buildPartial();
+          } else {
+            suiteResult_ = value;
+          }
+          onChanged();
+        } else {
+          suiteResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public Builder clearSuiteResult() {
+        if (suiteResultBuilder_ == null) {
+          suiteResult_ = null;
+          onChanged();
+        } else {
+          suiteResult_ = null;
+          suiteResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSuiteResult.Builder getSuiteResultBuilder() {
+        
+        onChanged();
+        return getSuiteResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSuiteResultOrBuilder getSuiteResultOrBuilder() {
+        if (suiteResultBuilder_ != null) {
+          return suiteResultBuilder_.getMessageOrBuilder();
+        } else {
+          return suiteResult_ == null ?
+              gauge.messages.Spec.ProtoSuiteResult.getDefaultInstance() : suiteResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the suite result in execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSuiteResult suiteResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSuiteResult, gauge.messages.Spec.ProtoSuiteResult.Builder, gauge.messages.Spec.ProtoSuiteResultOrBuilder> 
+          getSuiteResultFieldBuilder() {
+        if (suiteResultBuilder_ == null) {
+          suiteResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoSuiteResult, gauge.messages.Spec.ProtoSuiteResult.Builder, gauge.messages.Spec.ProtoSuiteResultOrBuilder>(
+                  getSuiteResult(),
+                  getParentForChildren(),
+                  isClean());
+          suiteResult_ = null;
+        }
+        return suiteResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -2286,17 +2989,57 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    boolean hasSpecResult();
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSpecResult getSpecResult();
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSpecResultOrBuilder getSpecResultOrBuilder();
   }
   /**
    * <pre>
@@ -2354,6 +3097,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoSpecResult.Builder subBuilder = null;
+              if (specResult_ != null) {
+                subBuilder = specResult_.toBuilder();
+              }
+              specResult_ = input.readMessage(gauge.messages.Spec.ProtoSpecResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(specResult_);
+                specResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -2389,22 +3145,70 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int SPECRESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoSpecResult specResult_;
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    public boolean hasSpecResult() {
+      return specResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSpecResult getSpecResult() {
+      return specResult_ == null ? gauge.messages.Spec.ProtoSpecResult.getDefaultInstance() : specResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSpecResultOrBuilder getSpecResultOrBuilder() {
+      return getSpecResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2424,6 +3228,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (specResult_ != null) {
+        output.writeMessage(2, getSpecResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -2436,6 +3243,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (specResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getSpecResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2458,6 +3269,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasSpecResult() == other.hasSpecResult());
+      if (hasSpecResult()) {
+        result = result && getSpecResult()
+            .equals(other.getSpecResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -2472,6 +3288,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasSpecResult()) {
+        hash = (37 * hash) + SPECRESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getSpecResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2616,6 +3436,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (specResultBuilder_ == null) {
+          specResult_ = null;
+        } else {
+          specResult_ = null;
+          specResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -2646,6 +3472,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (specResultBuilder_ == null) {
+          result.specResult_ = specResult_;
+        } else {
+          result.specResult_ = specResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -2698,6 +3529,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasSpecResult()) {
+          mergeSpecResult(other.getSpecResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -2731,12 +3565,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -2747,6 +3589,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -2763,6 +3609,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -2777,6 +3627,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -2795,6 +3649,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -2809,6 +3667,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -2817,6 +3679,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -2828,6 +3694,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -2842,6 +3712,168 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoSpecResult specResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSpecResult, gauge.messages.Spec.ProtoSpecResult.Builder, gauge.messages.Spec.ProtoSpecResultOrBuilder> specResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public boolean hasSpecResult() {
+        return specResultBuilder_ != null || specResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSpecResult getSpecResult() {
+        if (specResultBuilder_ == null) {
+          return specResult_ == null ? gauge.messages.Spec.ProtoSpecResult.getDefaultInstance() : specResult_;
+        } else {
+          return specResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder setSpecResult(gauge.messages.Spec.ProtoSpecResult value) {
+        if (specResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          specResult_ = value;
+          onChanged();
+        } else {
+          specResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder setSpecResult(
+          gauge.messages.Spec.ProtoSpecResult.Builder builderForValue) {
+        if (specResultBuilder_ == null) {
+          specResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          specResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder mergeSpecResult(gauge.messages.Spec.ProtoSpecResult value) {
+        if (specResultBuilder_ == null) {
+          if (specResult_ != null) {
+            specResult_ =
+              gauge.messages.Spec.ProtoSpecResult.newBuilder(specResult_).mergeFrom(value).buildPartial();
+          } else {
+            specResult_ = value;
+          }
+          onChanged();
+        } else {
+          specResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder clearSpecResult() {
+        if (specResultBuilder_ == null) {
+          specResult_ = null;
+          onChanged();
+        } else {
+          specResult_ = null;
+          specResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSpecResult.Builder getSpecResultBuilder() {
+        
+        onChanged();
+        return getSpecResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSpecResultOrBuilder getSpecResultOrBuilder() {
+        if (specResultBuilder_ != null) {
+          return specResultBuilder_.getMessageOrBuilder();
+        } else {
+          return specResult_ == null ?
+              gauge.messages.Spec.ProtoSpecResult.getDefaultInstance() : specResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSpecResult, gauge.messages.Spec.ProtoSpecResult.Builder, gauge.messages.Spec.ProtoSpecResultOrBuilder> 
+          getSpecResultFieldBuilder() {
+        if (specResultBuilder_ == null) {
+          specResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoSpecResult, gauge.messages.Spec.ProtoSpecResult.Builder, gauge.messages.Spec.ProtoSpecResultOrBuilder>(
+                  getSpecResult(),
+                  getParentForChildren(),
+                  isClean());
+          specResult_ = null;
+        }
+        return specResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -2901,17 +3933,54 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    boolean hasSpecResult();
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSpecResult getSpecResult();
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoSpecResultOrBuilder getSpecResultOrBuilder();
   }
   /**
    * <pre>
@@ -2969,6 +4038,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoSpecResult.Builder subBuilder = null;
+              if (specResult_ != null) {
+                subBuilder = specResult_.toBuilder();
+              }
+              specResult_ = input.readMessage(gauge.messages.Spec.ProtoSpecResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(specResult_);
+                specResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -3004,22 +4086,67 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current spec execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int SPECRESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoSpecResult specResult_;
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    public boolean hasSpecResult() {
+      return specResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSpecResult getSpecResult() {
+      return specResult_ == null ? gauge.messages.Spec.ProtoSpecResult.getDefaultInstance() : specResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the specs result in spec execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoSpecResultOrBuilder getSpecResultOrBuilder() {
+      return getSpecResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -3039,6 +4166,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (specResult_ != null) {
+        output.writeMessage(2, getSpecResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -3051,6 +4181,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (specResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getSpecResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3073,6 +4207,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasSpecResult() == other.hasSpecResult());
+      if (hasSpecResult()) {
+        result = result && getSpecResult()
+            .equals(other.getSpecResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -3087,6 +4226,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasSpecResult()) {
+        hash = (37 * hash) + SPECRESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getSpecResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -3231,6 +4374,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (specResultBuilder_ == null) {
+          specResult_ = null;
+        } else {
+          specResult_ = null;
+          specResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -3261,6 +4410,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (specResultBuilder_ == null) {
+          result.specResult_ = specResult_;
+        } else {
+          result.specResult_ = specResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -3313,6 +4467,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasSpecResult()) {
+          mergeSpecResult(other.getSpecResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -3346,12 +4503,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -3362,6 +4527,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -3378,6 +4547,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -3392,6 +4565,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -3410,6 +4587,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -3424,6 +4605,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -3432,6 +4617,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -3443,6 +4632,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current spec execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -3457,6 +4650,159 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoSpecResult specResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSpecResult, gauge.messages.Spec.ProtoSpecResult.Builder, gauge.messages.Spec.ProtoSpecResultOrBuilder> specResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public boolean hasSpecResult() {
+        return specResultBuilder_ != null || specResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSpecResult getSpecResult() {
+        if (specResultBuilder_ == null) {
+          return specResult_ == null ? gauge.messages.Spec.ProtoSpecResult.getDefaultInstance() : specResult_;
+        } else {
+          return specResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder setSpecResult(gauge.messages.Spec.ProtoSpecResult value) {
+        if (specResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          specResult_ = value;
+          onChanged();
+        } else {
+          specResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder setSpecResult(
+          gauge.messages.Spec.ProtoSpecResult.Builder builderForValue) {
+        if (specResultBuilder_ == null) {
+          specResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          specResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder mergeSpecResult(gauge.messages.Spec.ProtoSpecResult value) {
+        if (specResultBuilder_ == null) {
+          if (specResult_ != null) {
+            specResult_ =
+              gauge.messages.Spec.ProtoSpecResult.newBuilder(specResult_).mergeFrom(value).buildPartial();
+          } else {
+            specResult_ = value;
+          }
+          onChanged();
+        } else {
+          specResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public Builder clearSpecResult() {
+        if (specResultBuilder_ == null) {
+          specResult_ = null;
+          onChanged();
+        } else {
+          specResult_ = null;
+          specResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSpecResult.Builder getSpecResultBuilder() {
+        
+        onChanged();
+        return getSpecResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoSpecResultOrBuilder getSpecResultOrBuilder() {
+        if (specResultBuilder_ != null) {
+          return specResultBuilder_.getMessageOrBuilder();
+        } else {
+          return specResult_ == null ?
+              gauge.messages.Spec.ProtoSpecResult.getDefaultInstance() : specResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the specs result in spec execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoSpecResult specResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoSpecResult, gauge.messages.Spec.ProtoSpecResult.Builder, gauge.messages.Spec.ProtoSpecResultOrBuilder> 
+          getSpecResultFieldBuilder() {
+        if (specResultBuilder_ == null) {
+          specResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoSpecResult, gauge.messages.Spec.ProtoSpecResult.Builder, gauge.messages.Spec.ProtoSpecResultOrBuilder>(
+                  getSpecResult(),
+                  getParentForChildren(),
+                  isClean());
+          specResult_ = null;
+        }
+        return specResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -3516,17 +4862,57 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current sceanrio execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current sceanrio execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current sceanrio execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the scenarion result in scenarion execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    boolean hasScenarioResult();
+    /**
+     * <pre>
+     *&#47; Holds the scenarion result in scenarion execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoScenarioResult getScenarioResult();
+    /**
+     * <pre>
+     *&#47; Holds the scenarion result in scenarion execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoScenarioResultOrBuilder getScenarioResultOrBuilder();
   }
   /**
    * <pre>
@@ -3584,6 +4970,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoScenarioResult.Builder subBuilder = null;
+              if (scenarioResult_ != null) {
+                subBuilder = scenarioResult_.toBuilder();
+              }
+              scenarioResult_ = input.readMessage(gauge.messages.Spec.ProtoScenarioResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(scenarioResult_);
+                scenarioResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -3619,22 +5018,70 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current sceanrio execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current sceanrio execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current sceanrio execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int SCENARIORESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoScenarioResult scenarioResult_;
+    /**
+     * <pre>
+     *&#47; Holds the scenarion result in scenarion execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    public boolean hasScenarioResult() {
+      return scenarioResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the scenarion result in scenarion execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoScenarioResult getScenarioResult() {
+      return scenarioResult_ == null ? gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance() : scenarioResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the scenarion result in scenarion execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoScenarioResultOrBuilder getScenarioResultOrBuilder() {
+      return getScenarioResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -3654,6 +5101,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (scenarioResult_ != null) {
+        output.writeMessage(2, getScenarioResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -3666,6 +5116,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (scenarioResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getScenarioResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3688,6 +5142,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasScenarioResult() == other.hasScenarioResult());
+      if (hasScenarioResult()) {
+        result = result && getScenarioResult()
+            .equals(other.getScenarioResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -3702,6 +5161,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasScenarioResult()) {
+        hash = (37 * hash) + SCENARIORESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getScenarioResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -3846,6 +5309,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (scenarioResultBuilder_ == null) {
+          scenarioResult_ = null;
+        } else {
+          scenarioResult_ = null;
+          scenarioResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -3876,6 +5345,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (scenarioResultBuilder_ == null) {
+          result.scenarioResult_ = scenarioResult_;
+        } else {
+          result.scenarioResult_ = scenarioResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -3928,6 +5402,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasScenarioResult()) {
+          mergeScenarioResult(other.getScenarioResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -3961,12 +5438,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -3977,6 +5462,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -3993,6 +5482,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -4007,6 +5500,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -4025,6 +5522,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -4039,6 +5540,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -4047,6 +5552,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -4058,6 +5567,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current sceanrio execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -4072,6 +5585,168 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoScenarioResult scenarioResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoScenarioResult, gauge.messages.Spec.ProtoScenarioResult.Builder, gauge.messages.Spec.ProtoScenarioResultOrBuilder> scenarioResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public boolean hasScenarioResult() {
+        return scenarioResultBuilder_ != null || scenarioResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoScenarioResult getScenarioResult() {
+        if (scenarioResultBuilder_ == null) {
+          return scenarioResult_ == null ? gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance() : scenarioResult_;
+        } else {
+          return scenarioResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder setScenarioResult(gauge.messages.Spec.ProtoScenarioResult value) {
+        if (scenarioResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          scenarioResult_ = value;
+          onChanged();
+        } else {
+          scenarioResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder setScenarioResult(
+          gauge.messages.Spec.ProtoScenarioResult.Builder builderForValue) {
+        if (scenarioResultBuilder_ == null) {
+          scenarioResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          scenarioResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder mergeScenarioResult(gauge.messages.Spec.ProtoScenarioResult value) {
+        if (scenarioResultBuilder_ == null) {
+          if (scenarioResult_ != null) {
+            scenarioResult_ =
+              gauge.messages.Spec.ProtoScenarioResult.newBuilder(scenarioResult_).mergeFrom(value).buildPartial();
+          } else {
+            scenarioResult_ = value;
+          }
+          onChanged();
+        } else {
+          scenarioResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder clearScenarioResult() {
+        if (scenarioResultBuilder_ == null) {
+          scenarioResult_ = null;
+          onChanged();
+        } else {
+          scenarioResult_ = null;
+          scenarioResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoScenarioResult.Builder getScenarioResultBuilder() {
+        
+        onChanged();
+        return getScenarioResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoScenarioResultOrBuilder getScenarioResultOrBuilder() {
+        if (scenarioResultBuilder_ != null) {
+          return scenarioResultBuilder_.getMessageOrBuilder();
+        } else {
+          return scenarioResult_ == null ?
+              gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance() : scenarioResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenarion result in scenarion execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoScenarioResult, gauge.messages.Spec.ProtoScenarioResult.Builder, gauge.messages.Spec.ProtoScenarioResultOrBuilder> 
+          getScenarioResultFieldBuilder() {
+        if (scenarioResultBuilder_ == null) {
+          scenarioResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoScenarioResult, gauge.messages.Spec.ProtoScenarioResult.Builder, gauge.messages.Spec.ProtoScenarioResultOrBuilder>(
+                  getScenarioResult(),
+                  getParentForChildren(),
+                  isClean());
+          scenarioResult_ = null;
+        }
+        return scenarioResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -4131,17 +5806,42 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current scenario execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current scenario execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current scenario execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    boolean hasScenarioResult();
+    /**
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoScenarioResult getScenarioResult();
+    /**
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoScenarioResultOrBuilder getScenarioResultOrBuilder();
   }
   /**
    * <pre>
@@ -4199,6 +5899,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoScenarioResult.Builder subBuilder = null;
+              if (scenarioResult_ != null) {
+                subBuilder = scenarioResult_.toBuilder();
+              }
+              scenarioResult_ = input.readMessage(gauge.messages.Spec.ProtoScenarioResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(scenarioResult_);
+                scenarioResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -4234,22 +5947,55 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current scenario execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current scenario execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current scenario execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int SCENARIORESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoScenarioResult scenarioResult_;
+    /**
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    public boolean hasScenarioResult() {
+      return scenarioResult_ != null;
+    }
+    /**
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoScenarioResult getScenarioResult() {
+      return scenarioResult_ == null ? gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance() : scenarioResult_;
+    }
+    /**
+     * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoScenarioResultOrBuilder getScenarioResultOrBuilder() {
+      return getScenarioResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -4269,6 +6015,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (scenarioResult_ != null) {
+        output.writeMessage(2, getScenarioResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -4281,6 +6030,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (scenarioResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getScenarioResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -4303,6 +6056,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasScenarioResult() == other.hasScenarioResult());
+      if (hasScenarioResult()) {
+        result = result && getScenarioResult()
+            .equals(other.getScenarioResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -4317,6 +6075,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasScenarioResult()) {
+        hash = (37 * hash) + SCENARIORESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getScenarioResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -4461,6 +6223,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (scenarioResultBuilder_ == null) {
+          scenarioResult_ = null;
+        } else {
+          scenarioResult_ = null;
+          scenarioResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -4491,6 +6259,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (scenarioResultBuilder_ == null) {
+          result.scenarioResult_ = scenarioResult_;
+        } else {
+          result.scenarioResult_ = scenarioResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -4543,6 +6316,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasScenarioResult()) {
+          mergeScenarioResult(other.getScenarioResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -4576,12 +6352,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -4592,6 +6376,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -4608,6 +6396,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -4622,6 +6414,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -4640,6 +6436,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -4654,6 +6454,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -4662,6 +6466,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -4673,6 +6481,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current scenario execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -4687,6 +6499,123 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoScenarioResult scenarioResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoScenarioResult, gauge.messages.Spec.ProtoScenarioResult.Builder, gauge.messages.Spec.ProtoScenarioResultOrBuilder> scenarioResultBuilder_;
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public boolean hasScenarioResult() {
+        return scenarioResultBuilder_ != null || scenarioResult_ != null;
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoScenarioResult getScenarioResult() {
+        if (scenarioResultBuilder_ == null) {
+          return scenarioResult_ == null ? gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance() : scenarioResult_;
+        } else {
+          return scenarioResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder setScenarioResult(gauge.messages.Spec.ProtoScenarioResult value) {
+        if (scenarioResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          scenarioResult_ = value;
+          onChanged();
+        } else {
+          scenarioResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder setScenarioResult(
+          gauge.messages.Spec.ProtoScenarioResult.Builder builderForValue) {
+        if (scenarioResultBuilder_ == null) {
+          scenarioResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          scenarioResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder mergeScenarioResult(gauge.messages.Spec.ProtoScenarioResult value) {
+        if (scenarioResultBuilder_ == null) {
+          if (scenarioResult_ != null) {
+            scenarioResult_ =
+              gauge.messages.Spec.ProtoScenarioResult.newBuilder(scenarioResult_).mergeFrom(value).buildPartial();
+          } else {
+            scenarioResult_ = value;
+          }
+          onChanged();
+        } else {
+          scenarioResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public Builder clearScenarioResult() {
+        if (scenarioResultBuilder_ == null) {
+          scenarioResult_ = null;
+          onChanged();
+        } else {
+          scenarioResult_ = null;
+          scenarioResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoScenarioResult.Builder getScenarioResultBuilder() {
+        
+        onChanged();
+        return getScenarioResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoScenarioResultOrBuilder getScenarioResultOrBuilder() {
+        if (scenarioResultBuilder_ != null) {
+          return scenarioResultBuilder_.getMessageOrBuilder();
+        } else {
+          return scenarioResult_ == null ?
+              gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance() : scenarioResult_;
+        }
+      }
+      /**
+       * <code>.gauge.messages.ProtoScenarioResult scenarioResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoScenarioResult, gauge.messages.Spec.ProtoScenarioResult.Builder, gauge.messages.Spec.ProtoScenarioResultOrBuilder> 
+          getScenarioResultFieldBuilder() {
+        if (scenarioResultBuilder_ == null) {
+          scenarioResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoScenarioResult, gauge.messages.Spec.ProtoScenarioResult.Builder, gauge.messages.Spec.ProtoScenarioResultOrBuilder>(
+                  getScenarioResult(),
+                  getParentForChildren(),
+                  isClean());
+          scenarioResult_ = null;
+        }
+        return scenarioResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -4746,17 +6675,57 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    boolean hasStepResult();
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoStepResult getStepResult();
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoStepResultOrBuilder getStepResultOrBuilder();
   }
   /**
    * <pre>
@@ -4814,6 +6783,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoStepResult.Builder subBuilder = null;
+              if (stepResult_ != null) {
+                subBuilder = stepResult_.toBuilder();
+              }
+              stepResult_ = input.readMessage(gauge.messages.Spec.ProtoStepResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(stepResult_);
+                stepResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -4849,22 +6831,70 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int STEPRESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoStepResult stepResult_;
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    public boolean hasStepResult() {
+      return stepResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoStepResult getStepResult() {
+      return stepResult_ == null ? gauge.messages.Spec.ProtoStepResult.getDefaultInstance() : stepResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution starting.
+     * / Some fields will not be populated before execution.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoStepResultOrBuilder getStepResultOrBuilder() {
+      return getStepResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -4884,6 +6914,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (stepResult_ != null) {
+        output.writeMessage(2, getStepResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -4896,6 +6929,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (stepResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getStepResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -4918,6 +6955,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasStepResult() == other.hasStepResult());
+      if (hasStepResult()) {
+        result = result && getStepResult()
+            .equals(other.getStepResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -4932,6 +6974,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasStepResult()) {
+        hash = (37 * hash) + STEPRESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getStepResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -5076,6 +7122,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (stepResultBuilder_ == null) {
+          stepResult_ = null;
+        } else {
+          stepResult_ = null;
+          stepResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -5106,6 +7158,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (stepResultBuilder_ == null) {
+          result.stepResult_ = stepResult_;
+        } else {
+          result.stepResult_ = stepResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -5158,6 +7215,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasStepResult()) {
+          mergeStepResult(other.getStepResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -5191,12 +7251,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -5207,6 +7275,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -5223,6 +7295,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -5237,6 +7313,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -5255,6 +7335,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -5269,6 +7353,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -5277,6 +7365,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -5288,6 +7380,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -5302,6 +7398,168 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoStepResult stepResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoStepResult, gauge.messages.Spec.ProtoStepResult.Builder, gauge.messages.Spec.ProtoStepResultOrBuilder> stepResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public boolean hasStepResult() {
+        return stepResultBuilder_ != null || stepResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoStepResult getStepResult() {
+        if (stepResultBuilder_ == null) {
+          return stepResult_ == null ? gauge.messages.Spec.ProtoStepResult.getDefaultInstance() : stepResult_;
+        } else {
+          return stepResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder setStepResult(gauge.messages.Spec.ProtoStepResult value) {
+        if (stepResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          stepResult_ = value;
+          onChanged();
+        } else {
+          stepResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder setStepResult(
+          gauge.messages.Spec.ProtoStepResult.Builder builderForValue) {
+        if (stepResultBuilder_ == null) {
+          stepResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          stepResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder mergeStepResult(gauge.messages.Spec.ProtoStepResult value) {
+        if (stepResultBuilder_ == null) {
+          if (stepResult_ != null) {
+            stepResult_ =
+              gauge.messages.Spec.ProtoStepResult.newBuilder(stepResult_).mergeFrom(value).buildPartial();
+          } else {
+            stepResult_ = value;
+          }
+          onChanged();
+        } else {
+          stepResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder clearStepResult() {
+        if (stepResultBuilder_ == null) {
+          stepResult_ = null;
+          onChanged();
+        } else {
+          stepResult_ = null;
+          stepResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoStepResult.Builder getStepResultBuilder() {
+        
+        onChanged();
+        return getStepResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoStepResultOrBuilder getStepResultOrBuilder() {
+        if (stepResultBuilder_ != null) {
+          return stepResultBuilder_.getMessageOrBuilder();
+        } else {
+          return stepResult_ == null ?
+              gauge.messages.Spec.ProtoStepResult.getDefaultInstance() : stepResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution starting.
+       * / Some fields will not be populated before execution.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoStepResult, gauge.messages.Spec.ProtoStepResult.Builder, gauge.messages.Spec.ProtoStepResultOrBuilder> 
+          getStepResultFieldBuilder() {
+        if (stepResultBuilder_ == null) {
+          stepResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoStepResult, gauge.messages.Spec.ProtoStepResult.Builder, gauge.messages.Spec.ProtoStepResultOrBuilder>(
+                  getStepResult(),
+                  getParentForChildren(),
+                  isClean());
+          stepResult_ = null;
+        }
+        return stepResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -5361,17 +7619,54 @@ public final class Messages {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     boolean hasCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo();
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    boolean hasStepResult();
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoStepResult getStepResult();
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    gauge.messages.Spec.ProtoStepResultOrBuilder getStepResultOrBuilder();
   }
   /**
    * <pre>
@@ -5429,6 +7724,19 @@ public final class Messages {
 
               break;
             }
+            case 18: {
+              gauge.messages.Spec.ProtoStepResult.Builder subBuilder = null;
+              if (stepResult_ != null) {
+                subBuilder = stepResult_.toBuilder();
+              }
+              stepResult_ = input.readMessage(gauge.messages.Spec.ProtoStepResult.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(stepResult_);
+                stepResult_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -5464,22 +7772,67 @@ public final class Messages {
     public static final int CURRENTEXECUTIONINFO_FIELD_NUMBER = 1;
     private gauge.messages.Messages.ExecutionInfo currentExecutionInfo_;
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public boolean hasCurrentExecutionInfo() {
       return currentExecutionInfo_ != null;
     }
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
       return currentExecutionInfo_ == null ? gauge.messages.Messages.ExecutionInfo.getDefaultInstance() : currentExecutionInfo_;
     }
     /**
+     * <pre>
+     *&#47; Holds the current step execution info.
+     * </pre>
+     *
      * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
      */
     public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
       return getCurrentExecutionInfo();
+    }
+
+    public static final int STEPRESULT_FIELD_NUMBER = 2;
+    private gauge.messages.Spec.ProtoStepResult stepResult_;
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    public boolean hasStepResult() {
+      return stepResult_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoStepResult getStepResult() {
+      return stepResult_ == null ? gauge.messages.Spec.ProtoStepResult.getDefaultInstance() : stepResult_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds step result in step execution ending.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+     */
+    public gauge.messages.Spec.ProtoStepResultOrBuilder getStepResultOrBuilder() {
+      return getStepResult();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -5499,6 +7852,9 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         output.writeMessage(1, getCurrentExecutionInfo());
       }
+      if (stepResult_ != null) {
+        output.writeMessage(2, getStepResult());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -5511,6 +7867,10 @@ public final class Messages {
       if (currentExecutionInfo_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCurrentExecutionInfo());
+      }
+      if (stepResult_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getStepResult());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5533,6 +7893,11 @@ public final class Messages {
         result = result && getCurrentExecutionInfo()
             .equals(other.getCurrentExecutionInfo());
       }
+      result = result && (hasStepResult() == other.hasStepResult());
+      if (hasStepResult()) {
+        result = result && getStepResult()
+            .equals(other.getStepResult());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -5547,6 +7912,10 @@ public final class Messages {
       if (hasCurrentExecutionInfo()) {
         hash = (37 * hash) + CURRENTEXECUTIONINFO_FIELD_NUMBER;
         hash = (53 * hash) + getCurrentExecutionInfo().hashCode();
+      }
+      if (hasStepResult()) {
+        hash = (37 * hash) + STEPRESULT_FIELD_NUMBER;
+        hash = (53 * hash) + getStepResult().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -5691,6 +8060,12 @@ public final class Messages {
           currentExecutionInfo_ = null;
           currentExecutionInfoBuilder_ = null;
         }
+        if (stepResultBuilder_ == null) {
+          stepResult_ = null;
+        } else {
+          stepResult_ = null;
+          stepResultBuilder_ = null;
+        }
         return this;
       }
 
@@ -5721,6 +8096,11 @@ public final class Messages {
           result.currentExecutionInfo_ = currentExecutionInfo_;
         } else {
           result.currentExecutionInfo_ = currentExecutionInfoBuilder_.build();
+        }
+        if (stepResultBuilder_ == null) {
+          result.stepResult_ = stepResult_;
+        } else {
+          result.stepResult_ = stepResultBuilder_.build();
         }
         onBuilt();
         return result;
@@ -5773,6 +8153,9 @@ public final class Messages {
         if (other.hasCurrentExecutionInfo()) {
           mergeCurrentExecutionInfo(other.getCurrentExecutionInfo());
         }
+        if (other.hasStepResult()) {
+          mergeStepResult(other.getStepResult());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -5806,12 +8189,20 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilderV3<
           gauge.messages.Messages.ExecutionInfo, gauge.messages.Messages.ExecutionInfo.Builder, gauge.messages.Messages.ExecutionInfoOrBuilder> currentExecutionInfoBuilder_;
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public boolean hasCurrentExecutionInfo() {
         return currentExecutionInfoBuilder_ != null || currentExecutionInfo_ != null;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo getCurrentExecutionInfo() {
@@ -5822,6 +8213,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -5838,6 +8233,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder setCurrentExecutionInfo(
@@ -5852,6 +8251,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder mergeCurrentExecutionInfo(gauge.messages.Messages.ExecutionInfo value) {
@@ -5870,6 +8273,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public Builder clearCurrentExecutionInfo() {
@@ -5884,6 +8291,10 @@ public final class Messages {
         return this;
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfo.Builder getCurrentExecutionInfoBuilder() {
@@ -5892,6 +8303,10 @@ public final class Messages {
         return getCurrentExecutionInfoFieldBuilder().getBuilder();
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       public gauge.messages.Messages.ExecutionInfoOrBuilder getCurrentExecutionInfoOrBuilder() {
@@ -5903,6 +8318,10 @@ public final class Messages {
         }
       }
       /**
+       * <pre>
+       *&#47; Holds the current step execution info.
+       * </pre>
+       *
        * <code>.gauge.messages.ExecutionInfo currentExecutionInfo = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -5917,6 +8336,159 @@ public final class Messages {
           currentExecutionInfo_ = null;
         }
         return currentExecutionInfoBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoStepResult stepResult_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoStepResult, gauge.messages.Spec.ProtoStepResult.Builder, gauge.messages.Spec.ProtoStepResultOrBuilder> stepResultBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public boolean hasStepResult() {
+        return stepResultBuilder_ != null || stepResult_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoStepResult getStepResult() {
+        if (stepResultBuilder_ == null) {
+          return stepResult_ == null ? gauge.messages.Spec.ProtoStepResult.getDefaultInstance() : stepResult_;
+        } else {
+          return stepResultBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder setStepResult(gauge.messages.Spec.ProtoStepResult value) {
+        if (stepResultBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          stepResult_ = value;
+          onChanged();
+        } else {
+          stepResultBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder setStepResult(
+          gauge.messages.Spec.ProtoStepResult.Builder builderForValue) {
+        if (stepResultBuilder_ == null) {
+          stepResult_ = builderForValue.build();
+          onChanged();
+        } else {
+          stepResultBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder mergeStepResult(gauge.messages.Spec.ProtoStepResult value) {
+        if (stepResultBuilder_ == null) {
+          if (stepResult_ != null) {
+            stepResult_ =
+              gauge.messages.Spec.ProtoStepResult.newBuilder(stepResult_).mergeFrom(value).buildPartial();
+          } else {
+            stepResult_ = value;
+          }
+          onChanged();
+        } else {
+          stepResultBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public Builder clearStepResult() {
+        if (stepResultBuilder_ == null) {
+          stepResult_ = null;
+          onChanged();
+        } else {
+          stepResult_ = null;
+          stepResultBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoStepResult.Builder getStepResultBuilder() {
+        
+        onChanged();
+        return getStepResultFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      public gauge.messages.Spec.ProtoStepResultOrBuilder getStepResultOrBuilder() {
+        if (stepResultBuilder_ != null) {
+          return stepResultBuilder_.getMessageOrBuilder();
+        } else {
+          return stepResult_ == null ?
+              gauge.messages.Spec.ProtoStepResult.getDefaultInstance() : stepResult_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds step result in step execution ending.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoStepResult stepResult = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoStepResult, gauge.messages.Spec.ProtoStepResult.Builder, gauge.messages.Spec.ProtoStepResultOrBuilder> 
+          getStepResultFieldBuilder() {
+        if (stepResultBuilder_ == null) {
+          stepResultBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoStepResult, gauge.messages.Spec.ProtoStepResult.Builder, gauge.messages.Spec.ProtoStepResultOrBuilder>(
+                  getStepResult(),
+                  getParentForChildren(),
+                  isClean());
+          stepResult_ = null;
+        }
+        return stepResultBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -5966,6 +8538,862 @@ public final class Messages {
 
     @java.lang.Override
     public gauge.messages.Messages.StepExecutionEndingRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ExecutionArgOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gauge.messages.ExecutionArg)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     *&#47; Holds the flag name passed from command line.
+     * </pre>
+     *
+     * <code>string flagName = 1;</code>
+     */
+    java.lang.String getFlagName();
+    /**
+     * <pre>
+     *&#47; Holds the flag name passed from command line.
+     * </pre>
+     *
+     * <code>string flagName = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getFlagNameBytes();
+
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    java.util.List<java.lang.String>
+        getFlagValueList();
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    int getFlagValueCount();
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    java.lang.String getFlagValue(int index);
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getFlagValueBytes(int index);
+  }
+  /**
+   * <pre>
+   *&#47; Contains command line arguments which passed by user during execution.
+   * </pre>
+   *
+   * Protobuf type {@code gauge.messages.ExecutionArg}
+   */
+  public  static final class ExecutionArg extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:gauge.messages.ExecutionArg)
+      ExecutionArgOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ExecutionArg.newBuilder() to construct.
+    private ExecutionArg(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ExecutionArg() {
+      flagName_ = "";
+      flagValue_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ExecutionArg(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              flagName_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                flagValue_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              flagValue_.add(s);
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          flagValue_ = flagValue_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return gauge.messages.Messages.internal_static_gauge_messages_ExecutionArg_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return gauge.messages.Messages.internal_static_gauge_messages_ExecutionArg_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              gauge.messages.Messages.ExecutionArg.class, gauge.messages.Messages.ExecutionArg.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int FLAGNAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object flagName_;
+    /**
+     * <pre>
+     *&#47; Holds the flag name passed from command line.
+     * </pre>
+     *
+     * <code>string flagName = 1;</code>
+     */
+    public java.lang.String getFlagName() {
+      java.lang.Object ref = flagName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        flagName_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Holds the flag name passed from command line.
+     * </pre>
+     *
+     * <code>string flagName = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getFlagNameBytes() {
+      java.lang.Object ref = flagName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        flagName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int FLAGVALUE_FIELD_NUMBER = 2;
+    private com.google.protobuf.LazyStringList flagValue_;
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getFlagValueList() {
+      return flagValue_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    public int getFlagValueCount() {
+      return flagValue_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    public java.lang.String getFlagValue(int index) {
+      return flagValue_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Holds the flag value passed from command line.
+     * </pre>
+     *
+     * <code>repeated string flagValue = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getFlagValueBytes(int index) {
+      return flagValue_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getFlagNameBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, flagName_);
+      }
+      for (int i = 0; i < flagValue_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, flagValue_.getRaw(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getFlagNameBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, flagName_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < flagValue_.size(); i++) {
+          dataSize += computeStringSizeNoTag(flagValue_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getFlagValueList().size();
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof gauge.messages.Messages.ExecutionArg)) {
+        return super.equals(obj);
+      }
+      gauge.messages.Messages.ExecutionArg other = (gauge.messages.Messages.ExecutionArg) obj;
+
+      boolean result = true;
+      result = result && getFlagName()
+          .equals(other.getFlagName());
+      result = result && getFlagValueList()
+          .equals(other.getFlagValueList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + FLAGNAME_FIELD_NUMBER;
+      hash = (53 * hash) + getFlagName().hashCode();
+      if (getFlagValueCount() > 0) {
+        hash = (37 * hash) + FLAGVALUE_FIELD_NUMBER;
+        hash = (53 * hash) + getFlagValueList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.ExecutionArg parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(gauge.messages.Messages.ExecutionArg prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *&#47; Contains command line arguments which passed by user during execution.
+     * </pre>
+     *
+     * Protobuf type {@code gauge.messages.ExecutionArg}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gauge.messages.ExecutionArg)
+        gauge.messages.Messages.ExecutionArgOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return gauge.messages.Messages.internal_static_gauge_messages_ExecutionArg_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return gauge.messages.Messages.internal_static_gauge_messages_ExecutionArg_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                gauge.messages.Messages.ExecutionArg.class, gauge.messages.Messages.ExecutionArg.Builder.class);
+      }
+
+      // Construct using gauge.messages.Messages.ExecutionArg.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        flagName_ = "";
+
+        flagValue_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return gauge.messages.Messages.internal_static_gauge_messages_ExecutionArg_descriptor;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.ExecutionArg getDefaultInstanceForType() {
+        return gauge.messages.Messages.ExecutionArg.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.ExecutionArg build() {
+        gauge.messages.Messages.ExecutionArg result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.ExecutionArg buildPartial() {
+        gauge.messages.Messages.ExecutionArg result = new gauge.messages.Messages.ExecutionArg(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        result.flagName_ = flagName_;
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          flagValue_ = flagValue_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        }
+        result.flagValue_ = flagValue_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof gauge.messages.Messages.ExecutionArg) {
+          return mergeFrom((gauge.messages.Messages.ExecutionArg)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(gauge.messages.Messages.ExecutionArg other) {
+        if (other == gauge.messages.Messages.ExecutionArg.getDefaultInstance()) return this;
+        if (!other.getFlagName().isEmpty()) {
+          flagName_ = other.flagName_;
+          onChanged();
+        }
+        if (!other.flagValue_.isEmpty()) {
+          if (flagValue_.isEmpty()) {
+            flagValue_ = other.flagValue_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensureFlagValueIsMutable();
+            flagValue_.addAll(other.flagValue_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        gauge.messages.Messages.ExecutionArg parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (gauge.messages.Messages.ExecutionArg) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object flagName_ = "";
+      /**
+       * <pre>
+       *&#47; Holds the flag name passed from command line.
+       * </pre>
+       *
+       * <code>string flagName = 1;</code>
+       */
+      public java.lang.String getFlagName() {
+        java.lang.Object ref = flagName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          flagName_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag name passed from command line.
+       * </pre>
+       *
+       * <code>string flagName = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getFlagNameBytes() {
+        java.lang.Object ref = flagName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          flagName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag name passed from command line.
+       * </pre>
+       *
+       * <code>string flagName = 1;</code>
+       */
+      public Builder setFlagName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        flagName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag name passed from command line.
+       * </pre>
+       *
+       * <code>string flagName = 1;</code>
+       */
+      public Builder clearFlagName() {
+        
+        flagName_ = getDefaultInstance().getFlagName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag name passed from command line.
+       * </pre>
+       *
+       * <code>string flagName = 1;</code>
+       */
+      public Builder setFlagNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        flagName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList flagValue_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureFlagValueIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          flagValue_ = new com.google.protobuf.LazyStringArrayList(flagValue_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getFlagValueList() {
+        return flagValue_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public int getFlagValueCount() {
+        return flagValue_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public java.lang.String getFlagValue(int index) {
+        return flagValue_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getFlagValueBytes(int index) {
+        return flagValue_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public Builder setFlagValue(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureFlagValueIsMutable();
+        flagValue_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public Builder addFlagValue(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureFlagValueIsMutable();
+        flagValue_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public Builder addAllFlagValue(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureFlagValueIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, flagValue_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public Builder clearFlagValue() {
+        flagValue_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the flag value passed from command line.
+       * </pre>
+       *
+       * <code>repeated string flagValue = 2;</code>
+       */
+      public Builder addFlagValueBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureFlagValueIsMutable();
+        flagValue_.add(value);
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:gauge.messages.ExecutionArg)
+    }
+
+    // @@protoc_insertion_point(class_scope:gauge.messages.ExecutionArg)
+    private static final gauge.messages.Messages.ExecutionArg DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new gauge.messages.Messages.ExecutionArg();
+    }
+
+    public static gauge.messages.Messages.ExecutionArg getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ExecutionArg>
+        PARSER = new com.google.protobuf.AbstractParser<ExecutionArg>() {
+      @java.lang.Override
+      public ExecutionArg parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ExecutionArg(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ExecutionArg> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ExecutionArg> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public gauge.messages.Messages.ExecutionArg getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -6067,10 +9495,90 @@ public final class Messages {
      */
     com.google.protobuf.ByteString
         getStacktraceBytes();
+
+    /**
+     * <pre>
+     *&#47; Holds the project name
+     * </pre>
+     *
+     * <code>string projectName = 5;</code>
+     */
+    java.lang.String getProjectName();
+    /**
+     * <pre>
+     *&#47; Holds the project name
+     * </pre>
+     *
+     * <code>string projectName = 5;</code>
+     */
+    com.google.protobuf.ByteString
+        getProjectNameBytes();
+
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    java.util.List<gauge.messages.Messages.ExecutionArg> 
+        getExecutionArgsList();
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    gauge.messages.Messages.ExecutionArg getExecutionArgs(int index);
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    int getExecutionArgsCount();
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    java.util.List<? extends gauge.messages.Messages.ExecutionArgOrBuilder> 
+        getExecutionArgsOrBuilderList();
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    gauge.messages.Messages.ExecutionArgOrBuilder getExecutionArgsOrBuilder(
+        int index);
+
+    /**
+     * <pre>
+     *&#47; Holds the number of running execution streams.
+     * </pre>
+     *
+     * <code>int32 numberOfExecutionStreams = 7;</code>
+     */
+    int getNumberOfExecutionStreams();
+
+    /**
+     * <pre>
+     *&#47; Holds the runner id for parallel execution.
+     * </pre>
+     *
+     * <code>int32 runnerId = 8;</code>
+     */
+    int getRunnerId();
   }
   /**
    * <pre>
-   *&#47; Contains details of the execution. 
+   *&#47; Contains details of the execution.
    * / Depending on the context (Step, Scenario, Spec or Suite), the respective fields are set.
    * </pre>
    *
@@ -6087,6 +9595,10 @@ public final class Messages {
     }
     private ExecutionInfo() {
       stacktrace_ = "";
+      projectName_ = "";
+      executionArgs_ = java.util.Collections.emptyList();
+      numberOfExecutionStreams_ = 0;
+      runnerId_ = 0;
     }
 
     @java.lang.Override
@@ -6158,6 +9670,31 @@ public final class Messages {
               stacktrace_ = s;
               break;
             }
+            case 42: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              projectName_ = s;
+              break;
+            }
+            case 50: {
+              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+                executionArgs_ = new java.util.ArrayList<gauge.messages.Messages.ExecutionArg>();
+                mutable_bitField0_ |= 0x00000020;
+              }
+              executionArgs_.add(
+                  input.readMessage(gauge.messages.Messages.ExecutionArg.parser(), extensionRegistry));
+              break;
+            }
+            case 56: {
+
+              numberOfExecutionStreams_ = input.readInt32();
+              break;
+            }
+            case 64: {
+
+              runnerId_ = input.readInt32();
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -6173,6 +9710,9 @@ public final class Messages {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+          executionArgs_ = java.util.Collections.unmodifiableList(executionArgs_);
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -6190,6 +9730,7 @@ public final class Messages {
               gauge.messages.Messages.ExecutionInfo.class, gauge.messages.Messages.ExecutionInfo.Builder.class);
     }
 
+    private int bitField0_;
     public static final int CURRENTSPEC_FIELD_NUMBER = 1;
     private gauge.messages.Messages.SpecInfo currentSpec_;
     /**
@@ -6331,6 +9872,129 @@ public final class Messages {
       }
     }
 
+    public static final int PROJECTNAME_FIELD_NUMBER = 5;
+    private volatile java.lang.Object projectName_;
+    /**
+     * <pre>
+     *&#47; Holds the project name
+     * </pre>
+     *
+     * <code>string projectName = 5;</code>
+     */
+    public java.lang.String getProjectName() {
+      java.lang.Object ref = projectName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        projectName_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Holds the project name
+     * </pre>
+     *
+     * <code>string projectName = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getProjectNameBytes() {
+      java.lang.Object ref = projectName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        projectName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int EXECUTIONARGS_FIELD_NUMBER = 6;
+    private java.util.List<gauge.messages.Messages.ExecutionArg> executionArgs_;
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    public java.util.List<gauge.messages.Messages.ExecutionArg> getExecutionArgsList() {
+      return executionArgs_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    public java.util.List<? extends gauge.messages.Messages.ExecutionArgOrBuilder> 
+        getExecutionArgsOrBuilderList() {
+      return executionArgs_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    public int getExecutionArgsCount() {
+      return executionArgs_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    public gauge.messages.Messages.ExecutionArg getExecutionArgs(int index) {
+      return executionArgs_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Holds the command line arguments.
+     * </pre>
+     *
+     * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+     */
+    public gauge.messages.Messages.ExecutionArgOrBuilder getExecutionArgsOrBuilder(
+        int index) {
+      return executionArgs_.get(index);
+    }
+
+    public static final int NUMBEROFEXECUTIONSTREAMS_FIELD_NUMBER = 7;
+    private int numberOfExecutionStreams_;
+    /**
+     * <pre>
+     *&#47; Holds the number of running execution streams.
+     * </pre>
+     *
+     * <code>int32 numberOfExecutionStreams = 7;</code>
+     */
+    public int getNumberOfExecutionStreams() {
+      return numberOfExecutionStreams_;
+    }
+
+    public static final int RUNNERID_FIELD_NUMBER = 8;
+    private int runnerId_;
+    /**
+     * <pre>
+     *&#47; Holds the runner id for parallel execution.
+     * </pre>
+     *
+     * <code>int32 runnerId = 8;</code>
+     */
+    public int getRunnerId() {
+      return runnerId_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -6357,6 +10021,18 @@ public final class Messages {
       if (!getStacktraceBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, stacktrace_);
       }
+      if (!getProjectNameBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, projectName_);
+      }
+      for (int i = 0; i < executionArgs_.size(); i++) {
+        output.writeMessage(6, executionArgs_.get(i));
+      }
+      if (numberOfExecutionStreams_ != 0) {
+        output.writeInt32(7, numberOfExecutionStreams_);
+      }
+      if (runnerId_ != 0) {
+        output.writeInt32(8, runnerId_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -6380,6 +10056,21 @@ public final class Messages {
       }
       if (!getStacktraceBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, stacktrace_);
+      }
+      if (!getProjectNameBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, projectName_);
+      }
+      for (int i = 0; i < executionArgs_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, executionArgs_.get(i));
+      }
+      if (numberOfExecutionStreams_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(7, numberOfExecutionStreams_);
+      }
+      if (runnerId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(8, runnerId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -6414,6 +10105,14 @@ public final class Messages {
       }
       result = result && getStacktrace()
           .equals(other.getStacktrace());
+      result = result && getProjectName()
+          .equals(other.getProjectName());
+      result = result && getExecutionArgsList()
+          .equals(other.getExecutionArgsList());
+      result = result && (getNumberOfExecutionStreams()
+          == other.getNumberOfExecutionStreams());
+      result = result && (getRunnerId()
+          == other.getRunnerId());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -6439,6 +10138,16 @@ public final class Messages {
       }
       hash = (37 * hash) + STACKTRACE_FIELD_NUMBER;
       hash = (53 * hash) + getStacktrace().hashCode();
+      hash = (37 * hash) + PROJECTNAME_FIELD_NUMBER;
+      hash = (53 * hash) + getProjectName().hashCode();
+      if (getExecutionArgsCount() > 0) {
+        hash = (37 * hash) + EXECUTIONARGS_FIELD_NUMBER;
+        hash = (53 * hash) + getExecutionArgsList().hashCode();
+      }
+      hash = (37 * hash) + NUMBEROFEXECUTIONSTREAMS_FIELD_NUMBER;
+      hash = (53 * hash) + getNumberOfExecutionStreams();
+      hash = (37 * hash) + RUNNERID_FIELD_NUMBER;
+      hash = (53 * hash) + getRunnerId();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -6536,7 +10245,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; Contains details of the execution. 
+     *&#47; Contains details of the execution.
      * / Depending on the context (Step, Scenario, Spec or Suite), the respective fields are set.
      * </pre>
      *
@@ -6572,6 +10281,7 @@ public final class Messages {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
+          getExecutionArgsFieldBuilder();
         }
       }
       @java.lang.Override
@@ -6596,6 +10306,18 @@ public final class Messages {
           currentStepBuilder_ = null;
         }
         stacktrace_ = "";
+
+        projectName_ = "";
+
+        if (executionArgsBuilder_ == null) {
+          executionArgs_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000020);
+        } else {
+          executionArgsBuilder_.clear();
+        }
+        numberOfExecutionStreams_ = 0;
+
+        runnerId_ = 0;
 
         return this;
       }
@@ -6623,6 +10345,8 @@ public final class Messages {
       @java.lang.Override
       public gauge.messages.Messages.ExecutionInfo buildPartial() {
         gauge.messages.Messages.ExecutionInfo result = new gauge.messages.Messages.ExecutionInfo(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         if (currentSpecBuilder_ == null) {
           result.currentSpec_ = currentSpec_;
         } else {
@@ -6639,6 +10363,19 @@ public final class Messages {
           result.currentStep_ = currentStepBuilder_.build();
         }
         result.stacktrace_ = stacktrace_;
+        result.projectName_ = projectName_;
+        if (executionArgsBuilder_ == null) {
+          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+            executionArgs_ = java.util.Collections.unmodifiableList(executionArgs_);
+            bitField0_ = (bitField0_ & ~0x00000020);
+          }
+          result.executionArgs_ = executionArgs_;
+        } else {
+          result.executionArgs_ = executionArgsBuilder_.build();
+        }
+        result.numberOfExecutionStreams_ = numberOfExecutionStreams_;
+        result.runnerId_ = runnerId_;
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -6700,6 +10437,42 @@ public final class Messages {
           stacktrace_ = other.stacktrace_;
           onChanged();
         }
+        if (!other.getProjectName().isEmpty()) {
+          projectName_ = other.projectName_;
+          onChanged();
+        }
+        if (executionArgsBuilder_ == null) {
+          if (!other.executionArgs_.isEmpty()) {
+            if (executionArgs_.isEmpty()) {
+              executionArgs_ = other.executionArgs_;
+              bitField0_ = (bitField0_ & ~0x00000020);
+            } else {
+              ensureExecutionArgsIsMutable();
+              executionArgs_.addAll(other.executionArgs_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.executionArgs_.isEmpty()) {
+            if (executionArgsBuilder_.isEmpty()) {
+              executionArgsBuilder_.dispose();
+              executionArgsBuilder_ = null;
+              executionArgs_ = other.executionArgs_;
+              bitField0_ = (bitField0_ & ~0x00000020);
+              executionArgsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getExecutionArgsFieldBuilder() : null;
+            } else {
+              executionArgsBuilder_.addAllMessages(other.executionArgs_);
+            }
+          }
+        }
+        if (other.getNumberOfExecutionStreams() != 0) {
+          setNumberOfExecutionStreams(other.getNumberOfExecutionStreams());
+        }
+        if (other.getRunnerId() != 0) {
+          setRunnerId(other.getRunnerId());
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -6728,6 +10501,7 @@ public final class Messages {
         }
         return this;
       }
+      private int bitField0_;
 
       private gauge.messages.Messages.SpecInfo currentSpec_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -7273,6 +11047,483 @@ public final class Messages {
   checkByteStringIsUtf8(value);
         
         stacktrace_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object projectName_ = "";
+      /**
+       * <pre>
+       *&#47; Holds the project name
+       * </pre>
+       *
+       * <code>string projectName = 5;</code>
+       */
+      public java.lang.String getProjectName() {
+        java.lang.Object ref = projectName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          projectName_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the project name
+       * </pre>
+       *
+       * <code>string projectName = 5;</code>
+       */
+      public com.google.protobuf.ByteString
+          getProjectNameBytes() {
+        java.lang.Object ref = projectName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          projectName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the project name
+       * </pre>
+       *
+       * <code>string projectName = 5;</code>
+       */
+      public Builder setProjectName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        projectName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the project name
+       * </pre>
+       *
+       * <code>string projectName = 5;</code>
+       */
+      public Builder clearProjectName() {
+        
+        projectName_ = getDefaultInstance().getProjectName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the project name
+       * </pre>
+       *
+       * <code>string projectName = 5;</code>
+       */
+      public Builder setProjectNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        projectName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<gauge.messages.Messages.ExecutionArg> executionArgs_ =
+        java.util.Collections.emptyList();
+      private void ensureExecutionArgsIsMutable() {
+        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+          executionArgs_ = new java.util.ArrayList<gauge.messages.Messages.ExecutionArg>(executionArgs_);
+          bitField0_ |= 0x00000020;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          gauge.messages.Messages.ExecutionArg, gauge.messages.Messages.ExecutionArg.Builder, gauge.messages.Messages.ExecutionArgOrBuilder> executionArgsBuilder_;
+
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public java.util.List<gauge.messages.Messages.ExecutionArg> getExecutionArgsList() {
+        if (executionArgsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(executionArgs_);
+        } else {
+          return executionArgsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public int getExecutionArgsCount() {
+        if (executionArgsBuilder_ == null) {
+          return executionArgs_.size();
+        } else {
+          return executionArgsBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public gauge.messages.Messages.ExecutionArg getExecutionArgs(int index) {
+        if (executionArgsBuilder_ == null) {
+          return executionArgs_.get(index);
+        } else {
+          return executionArgsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder setExecutionArgs(
+          int index, gauge.messages.Messages.ExecutionArg value) {
+        if (executionArgsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExecutionArgsIsMutable();
+          executionArgs_.set(index, value);
+          onChanged();
+        } else {
+          executionArgsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder setExecutionArgs(
+          int index, gauge.messages.Messages.ExecutionArg.Builder builderForValue) {
+        if (executionArgsBuilder_ == null) {
+          ensureExecutionArgsIsMutable();
+          executionArgs_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          executionArgsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder addExecutionArgs(gauge.messages.Messages.ExecutionArg value) {
+        if (executionArgsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExecutionArgsIsMutable();
+          executionArgs_.add(value);
+          onChanged();
+        } else {
+          executionArgsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder addExecutionArgs(
+          int index, gauge.messages.Messages.ExecutionArg value) {
+        if (executionArgsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExecutionArgsIsMutable();
+          executionArgs_.add(index, value);
+          onChanged();
+        } else {
+          executionArgsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder addExecutionArgs(
+          gauge.messages.Messages.ExecutionArg.Builder builderForValue) {
+        if (executionArgsBuilder_ == null) {
+          ensureExecutionArgsIsMutable();
+          executionArgs_.add(builderForValue.build());
+          onChanged();
+        } else {
+          executionArgsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder addExecutionArgs(
+          int index, gauge.messages.Messages.ExecutionArg.Builder builderForValue) {
+        if (executionArgsBuilder_ == null) {
+          ensureExecutionArgsIsMutable();
+          executionArgs_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          executionArgsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder addAllExecutionArgs(
+          java.lang.Iterable<? extends gauge.messages.Messages.ExecutionArg> values) {
+        if (executionArgsBuilder_ == null) {
+          ensureExecutionArgsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, executionArgs_);
+          onChanged();
+        } else {
+          executionArgsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder clearExecutionArgs() {
+        if (executionArgsBuilder_ == null) {
+          executionArgs_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000020);
+          onChanged();
+        } else {
+          executionArgsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public Builder removeExecutionArgs(int index) {
+        if (executionArgsBuilder_ == null) {
+          ensureExecutionArgsIsMutable();
+          executionArgs_.remove(index);
+          onChanged();
+        } else {
+          executionArgsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public gauge.messages.Messages.ExecutionArg.Builder getExecutionArgsBuilder(
+          int index) {
+        return getExecutionArgsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public gauge.messages.Messages.ExecutionArgOrBuilder getExecutionArgsOrBuilder(
+          int index) {
+        if (executionArgsBuilder_ == null) {
+          return executionArgs_.get(index);  } else {
+          return executionArgsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public java.util.List<? extends gauge.messages.Messages.ExecutionArgOrBuilder> 
+           getExecutionArgsOrBuilderList() {
+        if (executionArgsBuilder_ != null) {
+          return executionArgsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(executionArgs_);
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public gauge.messages.Messages.ExecutionArg.Builder addExecutionArgsBuilder() {
+        return getExecutionArgsFieldBuilder().addBuilder(
+            gauge.messages.Messages.ExecutionArg.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public gauge.messages.Messages.ExecutionArg.Builder addExecutionArgsBuilder(
+          int index) {
+        return getExecutionArgsFieldBuilder().addBuilder(
+            index, gauge.messages.Messages.ExecutionArg.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       *&#47; Holds the command line arguments.
+       * </pre>
+       *
+       * <code>repeated .gauge.messages.ExecutionArg ExecutionArgs = 6;</code>
+       */
+      public java.util.List<gauge.messages.Messages.ExecutionArg.Builder> 
+           getExecutionArgsBuilderList() {
+        return getExecutionArgsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          gauge.messages.Messages.ExecutionArg, gauge.messages.Messages.ExecutionArg.Builder, gauge.messages.Messages.ExecutionArgOrBuilder> 
+          getExecutionArgsFieldBuilder() {
+        if (executionArgsBuilder_ == null) {
+          executionArgsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              gauge.messages.Messages.ExecutionArg, gauge.messages.Messages.ExecutionArg.Builder, gauge.messages.Messages.ExecutionArgOrBuilder>(
+                  executionArgs_,
+                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  getParentForChildren(),
+                  isClean());
+          executionArgs_ = null;
+        }
+        return executionArgsBuilder_;
+      }
+
+      private int numberOfExecutionStreams_ ;
+      /**
+       * <pre>
+       *&#47; Holds the number of running execution streams.
+       * </pre>
+       *
+       * <code>int32 numberOfExecutionStreams = 7;</code>
+       */
+      public int getNumberOfExecutionStreams() {
+        return numberOfExecutionStreams_;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the number of running execution streams.
+       * </pre>
+       *
+       * <code>int32 numberOfExecutionStreams = 7;</code>
+       */
+      public Builder setNumberOfExecutionStreams(int value) {
+        
+        numberOfExecutionStreams_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the number of running execution streams.
+       * </pre>
+       *
+       * <code>int32 numberOfExecutionStreams = 7;</code>
+       */
+      public Builder clearNumberOfExecutionStreams() {
+        
+        numberOfExecutionStreams_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int runnerId_ ;
+      /**
+       * <pre>
+       *&#47; Holds the runner id for parallel execution.
+       * </pre>
+       *
+       * <code>int32 runnerId = 8;</code>
+       */
+      public int getRunnerId() {
+        return runnerId_;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the runner id for parallel execution.
+       * </pre>
+       *
+       * <code>int32 runnerId = 8;</code>
+       */
+      public Builder setRunnerId(int value) {
+        
+        runnerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the runner id for parallel execution.
+       * </pre>
+       *
+       * <code>int32 runnerId = 8;</code>
+       */
+      public Builder clearRunnerId() {
+        
+        runnerId_ = 0;
         onChanged();
         return this;
       }
@@ -10493,7 +14744,7 @@ public final class Messages {
 
     /**
      * <pre>
-     *&#47; Contains the actual text of the Step being executed. 
+     *&#47; Contains the actual text of the Step being executed.
      * / This contains the parameters as defined in the Spec.
      * </pre>
      *
@@ -10502,7 +14753,7 @@ public final class Messages {
     java.lang.String getActualStepText();
     /**
      * <pre>
-     *&#47; Contains the actual text of the Step being executed. 
+     *&#47; Contains the actual text of the Step being executed.
      * / This contains the parameters as defined in the Spec.
      * </pre>
      *
@@ -10513,7 +14764,7 @@ public final class Messages {
 
     /**
      * <pre>
-     *&#47; Contains the parsed text of the Step being executed. 
+     *&#47; Contains the parsed text of the Step being executed.
      * / The paramters are replaced with placeholders.
      * </pre>
      *
@@ -10522,7 +14773,7 @@ public final class Messages {
     java.lang.String getParsedStepText();
     /**
      * <pre>
-     *&#47; Contains the parsed text of the Step being executed. 
+     *&#47; Contains the parsed text of the Step being executed.
      * / The paramters are replaced with placeholders.
      * </pre>
      *
@@ -10697,7 +14948,7 @@ public final class Messages {
     private volatile java.lang.Object actualStepText_;
     /**
      * <pre>
-     *&#47; Contains the actual text of the Step being executed. 
+     *&#47; Contains the actual text of the Step being executed.
      * / This contains the parameters as defined in the Spec.
      * </pre>
      *
@@ -10717,7 +14968,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; Contains the actual text of the Step being executed. 
+     *&#47; Contains the actual text of the Step being executed.
      * / This contains the parameters as defined in the Spec.
      * </pre>
      *
@@ -10741,7 +14992,7 @@ public final class Messages {
     private volatile java.lang.Object parsedStepText_;
     /**
      * <pre>
-     *&#47; Contains the parsed text of the Step being executed. 
+     *&#47; Contains the parsed text of the Step being executed.
      * / The paramters are replaced with placeholders.
      * </pre>
      *
@@ -10761,7 +15012,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; Contains the parsed text of the Step being executed. 
+     *&#47; Contains the parsed text of the Step being executed.
      * / The paramters are replaced with placeholders.
      * </pre>
      *
@@ -11253,7 +15504,7 @@ public final class Messages {
       private java.lang.Object actualStepText_ = "";
       /**
        * <pre>
-       *&#47; Contains the actual text of the Step being executed. 
+       *&#47; Contains the actual text of the Step being executed.
        * / This contains the parameters as defined in the Spec.
        * </pre>
        *
@@ -11273,7 +15524,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the actual text of the Step being executed. 
+       *&#47; Contains the actual text of the Step being executed.
        * / This contains the parameters as defined in the Spec.
        * </pre>
        *
@@ -11294,7 +15545,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the actual text of the Step being executed. 
+       *&#47; Contains the actual text of the Step being executed.
        * / This contains the parameters as defined in the Spec.
        * </pre>
        *
@@ -11312,7 +15563,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the actual text of the Step being executed. 
+       *&#47; Contains the actual text of the Step being executed.
        * / This contains the parameters as defined in the Spec.
        * </pre>
        *
@@ -11326,7 +15577,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the actual text of the Step being executed. 
+       *&#47; Contains the actual text of the Step being executed.
        * / This contains the parameters as defined in the Spec.
        * </pre>
        *
@@ -11347,7 +15598,7 @@ public final class Messages {
       private java.lang.Object parsedStepText_ = "";
       /**
        * <pre>
-       *&#47; Contains the parsed text of the Step being executed. 
+       *&#47; Contains the parsed text of the Step being executed.
        * / The paramters are replaced with placeholders.
        * </pre>
        *
@@ -11367,7 +15618,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the parsed text of the Step being executed. 
+       *&#47; Contains the parsed text of the Step being executed.
        * / The paramters are replaced with placeholders.
        * </pre>
        *
@@ -11388,7 +15639,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the parsed text of the Step being executed. 
+       *&#47; Contains the parsed text of the Step being executed.
        * / The paramters are replaced with placeholders.
        * </pre>
        *
@@ -11406,7 +15657,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the parsed text of the Step being executed. 
+       *&#47; Contains the parsed text of the Step being executed.
        * / The paramters are replaced with placeholders.
        * </pre>
        *
@@ -11420,7 +15671,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Contains the parsed text of the Step being executed. 
+       *&#47; Contains the parsed text of the Step being executed.
        * / The paramters are replaced with placeholders.
        * </pre>
        *
@@ -11898,7 +16149,7 @@ public final class Messages {
   }
   /**
    * <pre>
-   *&#47; Request sent ot the runner to check if given Step is valid. 
+   *&#47; Request sent ot the runner to check if given Step is valid.
    * / The runner should check if there is an implementation defined for the given Step Text.
    * </pre>
    *
@@ -12270,7 +16521,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; Request sent ot the runner to check if given Step is valid. 
+     *&#47; Request sent ot the runner to check if given Step is valid.
      * / The runner should check if there is an implementation defined for the given Step Text.
      * </pre>
      *
@@ -12814,7 +17065,7 @@ public final class Messages {
   /**
    * <pre>
    *&#47; Response of StepValidateRequest.
-   * / The runner tells the caller if the Request was valid, 
+   * / The runner tells the caller if the Request was valid,
    * / i.e. an implementation exists for given Step text.
    * / Returns an error message if it is an error response.
    * </pre>
@@ -13298,7 +17549,7 @@ public final class Messages {
     /**
      * <pre>
      *&#47; Response of StepValidateRequest.
-     * / The runner tells the caller if the Request was valid, 
+     * / The runner tells the caller if the Request was valid,
      * / i.e. an implementation exists for given Step text.
      * / Returns an error message if it is an error response.
      * </pre>
@@ -14340,6 +18591,613 @@ public final class Messages {
 
     @java.lang.Override
     public gauge.messages.Messages.SuiteExecutionResult getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface SuiteExecutionResultItemOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gauge.messages.SuiteExecutionResultItem)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+     */
+    boolean hasResultItem();
+    /**
+     * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+     */
+    gauge.messages.Spec.ProtoItem getResultItem();
+    /**
+     * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+     */
+    gauge.messages.Spec.ProtoItemOrBuilder getResultItemOrBuilder();
+  }
+  /**
+   * Protobuf type {@code gauge.messages.SuiteExecutionResultItem}
+   */
+  public  static final class SuiteExecutionResultItem extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:gauge.messages.SuiteExecutionResultItem)
+      SuiteExecutionResultItemOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use SuiteExecutionResultItem.newBuilder() to construct.
+    private SuiteExecutionResultItem(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private SuiteExecutionResultItem() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SuiteExecutionResultItem(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              gauge.messages.Spec.ProtoItem.Builder subBuilder = null;
+              if (resultItem_ != null) {
+                subBuilder = resultItem_.toBuilder();
+              }
+              resultItem_ = input.readMessage(gauge.messages.Spec.ProtoItem.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(resultItem_);
+                resultItem_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return gauge.messages.Messages.internal_static_gauge_messages_SuiteExecutionResultItem_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return gauge.messages.Messages.internal_static_gauge_messages_SuiteExecutionResultItem_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              gauge.messages.Messages.SuiteExecutionResultItem.class, gauge.messages.Messages.SuiteExecutionResultItem.Builder.class);
+    }
+
+    public static final int RESULTITEM_FIELD_NUMBER = 1;
+    private gauge.messages.Spec.ProtoItem resultItem_;
+    /**
+     * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+     */
+    public boolean hasResultItem() {
+      return resultItem_ != null;
+    }
+    /**
+     * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+     */
+    public gauge.messages.Spec.ProtoItem getResultItem() {
+      return resultItem_ == null ? gauge.messages.Spec.ProtoItem.getDefaultInstance() : resultItem_;
+    }
+    /**
+     * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+     */
+    public gauge.messages.Spec.ProtoItemOrBuilder getResultItemOrBuilder() {
+      return getResultItem();
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (resultItem_ != null) {
+        output.writeMessage(1, getResultItem());
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (resultItem_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getResultItem());
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof gauge.messages.Messages.SuiteExecutionResultItem)) {
+        return super.equals(obj);
+      }
+      gauge.messages.Messages.SuiteExecutionResultItem other = (gauge.messages.Messages.SuiteExecutionResultItem) obj;
+
+      boolean result = true;
+      result = result && (hasResultItem() == other.hasResultItem());
+      if (hasResultItem()) {
+        result = result && getResultItem()
+            .equals(other.getResultItem());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasResultItem()) {
+        hash = (37 * hash) + RESULTITEM_FIELD_NUMBER;
+        hash = (53 * hash) + getResultItem().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.SuiteExecutionResultItem parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(gauge.messages.Messages.SuiteExecutionResultItem prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gauge.messages.SuiteExecutionResultItem}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gauge.messages.SuiteExecutionResultItem)
+        gauge.messages.Messages.SuiteExecutionResultItemOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return gauge.messages.Messages.internal_static_gauge_messages_SuiteExecutionResultItem_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return gauge.messages.Messages.internal_static_gauge_messages_SuiteExecutionResultItem_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                gauge.messages.Messages.SuiteExecutionResultItem.class, gauge.messages.Messages.SuiteExecutionResultItem.Builder.class);
+      }
+
+      // Construct using gauge.messages.Messages.SuiteExecutionResultItem.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (resultItemBuilder_ == null) {
+          resultItem_ = null;
+        } else {
+          resultItem_ = null;
+          resultItemBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return gauge.messages.Messages.internal_static_gauge_messages_SuiteExecutionResultItem_descriptor;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.SuiteExecutionResultItem getDefaultInstanceForType() {
+        return gauge.messages.Messages.SuiteExecutionResultItem.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.SuiteExecutionResultItem build() {
+        gauge.messages.Messages.SuiteExecutionResultItem result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.SuiteExecutionResultItem buildPartial() {
+        gauge.messages.Messages.SuiteExecutionResultItem result = new gauge.messages.Messages.SuiteExecutionResultItem(this);
+        if (resultItemBuilder_ == null) {
+          result.resultItem_ = resultItem_;
+        } else {
+          result.resultItem_ = resultItemBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof gauge.messages.Messages.SuiteExecutionResultItem) {
+          return mergeFrom((gauge.messages.Messages.SuiteExecutionResultItem)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(gauge.messages.Messages.SuiteExecutionResultItem other) {
+        if (other == gauge.messages.Messages.SuiteExecutionResultItem.getDefaultInstance()) return this;
+        if (other.hasResultItem()) {
+          mergeResultItem(other.getResultItem());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        gauge.messages.Messages.SuiteExecutionResultItem parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (gauge.messages.Messages.SuiteExecutionResultItem) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private gauge.messages.Spec.ProtoItem resultItem_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder> resultItemBuilder_;
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public boolean hasResultItem() {
+        return resultItemBuilder_ != null || resultItem_ != null;
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItem getResultItem() {
+        if (resultItemBuilder_ == null) {
+          return resultItem_ == null ? gauge.messages.Spec.ProtoItem.getDefaultInstance() : resultItem_;
+        } else {
+          return resultItemBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public Builder setResultItem(gauge.messages.Spec.ProtoItem value) {
+        if (resultItemBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          resultItem_ = value;
+          onChanged();
+        } else {
+          resultItemBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public Builder setResultItem(
+          gauge.messages.Spec.ProtoItem.Builder builderForValue) {
+        if (resultItemBuilder_ == null) {
+          resultItem_ = builderForValue.build();
+          onChanged();
+        } else {
+          resultItemBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public Builder mergeResultItem(gauge.messages.Spec.ProtoItem value) {
+        if (resultItemBuilder_ == null) {
+          if (resultItem_ != null) {
+            resultItem_ =
+              gauge.messages.Spec.ProtoItem.newBuilder(resultItem_).mergeFrom(value).buildPartial();
+          } else {
+            resultItem_ = value;
+          }
+          onChanged();
+        } else {
+          resultItemBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public Builder clearResultItem() {
+        if (resultItemBuilder_ == null) {
+          resultItem_ = null;
+          onChanged();
+        } else {
+          resultItem_ = null;
+          resultItemBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItem.Builder getResultItemBuilder() {
+        
+        onChanged();
+        return getResultItemFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItemOrBuilder getResultItemOrBuilder() {
+        if (resultItemBuilder_ != null) {
+          return resultItemBuilder_.getMessageOrBuilder();
+        } else {
+          return resultItem_ == null ?
+              gauge.messages.Spec.ProtoItem.getDefaultInstance() : resultItem_;
+        }
+      }
+      /**
+       * <code>.gauge.messages.ProtoItem resultItem = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder> 
+          getResultItemFieldBuilder() {
+        if (resultItemBuilder_ == null) {
+          resultItemBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder>(
+                  getResultItem(),
+                  getParentForChildren(),
+                  isClean());
+          resultItem_ = null;
+        }
+        return resultItemBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:gauge.messages.SuiteExecutionResultItem)
+    }
+
+    // @@protoc_insertion_point(class_scope:gauge.messages.SuiteExecutionResultItem)
+    private static final gauge.messages.Messages.SuiteExecutionResultItem DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new gauge.messages.Messages.SuiteExecutionResultItem();
+    }
+
+    public static gauge.messages.Messages.SuiteExecutionResultItem getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SuiteExecutionResultItem>
+        PARSER = new com.google.protobuf.AbstractParser<SuiteExecutionResultItem>() {
+      @java.lang.Override
+      public SuiteExecutionResultItem parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new SuiteExecutionResultItem(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<SuiteExecutionResultItem> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SuiteExecutionResultItem> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public gauge.messages.Messages.SuiteExecutionResultItem getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -21249,7 +26107,7 @@ public final class Messages {
 
     /**
      * <pre>
-     *&#47; Step text to lookup the Step. 
+     *&#47; Step text to lookup the Step.
      * / This is the parsed step value, i.e. with placeholders for parameters.
      * </pre>
      *
@@ -21258,7 +26116,7 @@ public final class Messages {
     java.lang.String getStepValue();
     /**
      * <pre>
-     *&#47; Step text to lookup the Step. 
+     *&#47; Step text to lookup the Step.
      * / This is the parsed step value, i.e. with placeholders for parameters.
      * </pre>
      *
@@ -21353,7 +26211,7 @@ public final class Messages {
     private volatile java.lang.Object stepValue_;
     /**
      * <pre>
-     *&#47; Step text to lookup the Step. 
+     *&#47; Step text to lookup the Step.
      * / This is the parsed step value, i.e. with placeholders for parameters.
      * </pre>
      *
@@ -21373,7 +26231,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; Step text to lookup the Step. 
+     *&#47; Step text to lookup the Step.
      * / This is the parsed step value, i.e. with placeholders for parameters.
      * </pre>
      *
@@ -21703,7 +26561,7 @@ public final class Messages {
       private java.lang.Object stepValue_ = "";
       /**
        * <pre>
-       *&#47; Step text to lookup the Step. 
+       *&#47; Step text to lookup the Step.
        * / This is the parsed step value, i.e. with placeholders for parameters.
        * </pre>
        *
@@ -21723,7 +26581,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Step text to lookup the Step. 
+       *&#47; Step text to lookup the Step.
        * / This is the parsed step value, i.e. with placeholders for parameters.
        * </pre>
        *
@@ -21744,7 +26602,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Step text to lookup the Step. 
+       *&#47; Step text to lookup the Step.
        * / This is the parsed step value, i.e. with placeholders for parameters.
        * </pre>
        *
@@ -21762,7 +26620,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Step text to lookup the Step. 
+       *&#47; Step text to lookup the Step.
        * / This is the parsed step value, i.e. with placeholders for parameters.
        * </pre>
        *
@@ -21776,7 +26634,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; Step text to lookup the Step. 
+       *&#47; Step text to lookup the Step.
        * / This is the parsed step value, i.e. with placeholders for parameters.
        * </pre>
        *
@@ -21861,7 +26719,7 @@ public final class Messages {
 
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -21870,7 +26728,7 @@ public final class Messages {
         getStepNameList();
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -21878,7 +26736,7 @@ public final class Messages {
     int getStepNameCount();
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -21886,7 +26744,7 @@ public final class Messages {
     java.lang.String getStepName(int index);
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -22084,7 +26942,7 @@ public final class Messages {
     private com.google.protobuf.LazyStringList stepName_;
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -22095,7 +26953,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -22105,7 +26963,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -22115,7 +26973,7 @@ public final class Messages {
     }
     /**
      * <pre>
-     *&#47; The Step name of the given step. 
+     *&#47; The Step name of the given step.
      * </pre>
      *
      * <code>repeated string stepName = 2;</code>
@@ -22671,7 +27529,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22682,7 +27540,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22692,7 +27550,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22702,7 +27560,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22713,7 +27571,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22730,7 +27588,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22747,7 +27605,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22762,7 +27620,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -22775,7 +27633,7 @@ public final class Messages {
       }
       /**
        * <pre>
-       *&#47; The Step name of the given step. 
+       *&#47; The Step name of the given step.
        * </pre>
        *
        * <code>repeated string stepName = 2;</code>
@@ -25650,7 +30508,7 @@ public final class Messages {
       private StepPosition(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
       }
-      public StepPosition() {
+      private StepPosition() {
         stepValue_ = "";
       }
 
@@ -27827,7 +32685,7 @@ public final class Messages {
     private ImplementationFileGlobPatternResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    public ImplementationFileGlobPatternResponse() {
+    private ImplementationFileGlobPatternResponse() {
       globPatterns_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
@@ -28927,7 +33785,7 @@ public final class Messages {
     private ImplementationFileListResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    public ImplementationFileListResponse() {
+    private ImplementationFileListResponse() {
       implementationFilePaths_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
@@ -31338,7 +36196,7 @@ public final class Messages {
     private FileDiff(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    public FileDiff() {
+    private FileDiff() {
       filePath_ = "";
       textDiffs_ = java.util.Collections.emptyList();
     }
@@ -32334,6 +37192,1020 @@ public final class Messages {
 
   }
 
+  public interface KeepAliveOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gauge.messages.KeepAlive)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     *&#47; ID of the plugin initiating this request
+     * </pre>
+     *
+     * <code>string pluginId = 1;</code>
+     */
+    java.lang.String getPluginId();
+    /**
+     * <pre>
+     *&#47; ID of the plugin initiating this request
+     * </pre>
+     *
+     * <code>string pluginId = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getPluginIdBytes();
+  }
+  /**
+   * <pre>
+   *&#47; Tell gauge to reset the kill timer, thus extending the life
+   * </pre>
+   *
+   * Protobuf type {@code gauge.messages.KeepAlive}
+   */
+  public  static final class KeepAlive extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:gauge.messages.KeepAlive)
+      KeepAliveOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use KeepAlive.newBuilder() to construct.
+    private KeepAlive(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private KeepAlive() {
+      pluginId_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private KeepAlive(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              pluginId_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return gauge.messages.Messages.internal_static_gauge_messages_KeepAlive_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return gauge.messages.Messages.internal_static_gauge_messages_KeepAlive_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              gauge.messages.Messages.KeepAlive.class, gauge.messages.Messages.KeepAlive.Builder.class);
+    }
+
+    public static final int PLUGINID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object pluginId_;
+    /**
+     * <pre>
+     *&#47; ID of the plugin initiating this request
+     * </pre>
+     *
+     * <code>string pluginId = 1;</code>
+     */
+    public java.lang.String getPluginId() {
+      java.lang.Object ref = pluginId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        pluginId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; ID of the plugin initiating this request
+     * </pre>
+     *
+     * <code>string pluginId = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPluginIdBytes() {
+      java.lang.Object ref = pluginId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        pluginId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getPluginIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, pluginId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getPluginIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, pluginId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof gauge.messages.Messages.KeepAlive)) {
+        return super.equals(obj);
+      }
+      gauge.messages.Messages.KeepAlive other = (gauge.messages.Messages.KeepAlive) obj;
+
+      boolean result = true;
+      result = result && getPluginId()
+          .equals(other.getPluginId());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + PLUGINID_FIELD_NUMBER;
+      hash = (53 * hash) + getPluginId().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.KeepAlive parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.KeepAlive parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.KeepAlive parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(gauge.messages.Messages.KeepAlive prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *&#47; Tell gauge to reset the kill timer, thus extending the life
+     * </pre>
+     *
+     * Protobuf type {@code gauge.messages.KeepAlive}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gauge.messages.KeepAlive)
+        gauge.messages.Messages.KeepAliveOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return gauge.messages.Messages.internal_static_gauge_messages_KeepAlive_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return gauge.messages.Messages.internal_static_gauge_messages_KeepAlive_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                gauge.messages.Messages.KeepAlive.class, gauge.messages.Messages.KeepAlive.Builder.class);
+      }
+
+      // Construct using gauge.messages.Messages.KeepAlive.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        pluginId_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return gauge.messages.Messages.internal_static_gauge_messages_KeepAlive_descriptor;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.KeepAlive getDefaultInstanceForType() {
+        return gauge.messages.Messages.KeepAlive.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.KeepAlive build() {
+        gauge.messages.Messages.KeepAlive result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.KeepAlive buildPartial() {
+        gauge.messages.Messages.KeepAlive result = new gauge.messages.Messages.KeepAlive(this);
+        result.pluginId_ = pluginId_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof gauge.messages.Messages.KeepAlive) {
+          return mergeFrom((gauge.messages.Messages.KeepAlive)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(gauge.messages.Messages.KeepAlive other) {
+        if (other == gauge.messages.Messages.KeepAlive.getDefaultInstance()) return this;
+        if (!other.getPluginId().isEmpty()) {
+          pluginId_ = other.pluginId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        gauge.messages.Messages.KeepAlive parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (gauge.messages.Messages.KeepAlive) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object pluginId_ = "";
+      /**
+       * <pre>
+       *&#47; ID of the plugin initiating this request
+       * </pre>
+       *
+       * <code>string pluginId = 1;</code>
+       */
+      public java.lang.String getPluginId() {
+        java.lang.Object ref = pluginId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          pluginId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; ID of the plugin initiating this request
+       * </pre>
+       *
+       * <code>string pluginId = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPluginIdBytes() {
+        java.lang.Object ref = pluginId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          pluginId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; ID of the plugin initiating this request
+       * </pre>
+       *
+       * <code>string pluginId = 1;</code>
+       */
+      public Builder setPluginId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        pluginId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; ID of the plugin initiating this request
+       * </pre>
+       *
+       * <code>string pluginId = 1;</code>
+       */
+      public Builder clearPluginId() {
+        
+        pluginId_ = getDefaultInstance().getPluginId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; ID of the plugin initiating this request
+       * </pre>
+       *
+       * <code>string pluginId = 1;</code>
+       */
+      public Builder setPluginIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        pluginId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:gauge.messages.KeepAlive)
+    }
+
+    // @@protoc_insertion_point(class_scope:gauge.messages.KeepAlive)
+    private static final gauge.messages.Messages.KeepAlive DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new gauge.messages.Messages.KeepAlive();
+    }
+
+    public static gauge.messages.Messages.KeepAlive getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<KeepAlive>
+        PARSER = new com.google.protobuf.AbstractParser<KeepAlive>() {
+      @java.lang.Override
+      public KeepAlive parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new KeepAlive(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<KeepAlive> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<KeepAlive> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public gauge.messages.Messages.KeepAlive getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface EmptyOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gauge.messages.Empty)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * <pre>
+   * Empty is a blank response, to be used when there is no return expected.
+   * </pre>
+   *
+   * Protobuf type {@code gauge.messages.Empty}
+   */
+  public  static final class Empty extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:gauge.messages.Empty)
+      EmptyOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use Empty.newBuilder() to construct.
+    private Empty(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private Empty() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Empty(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return gauge.messages.Messages.internal_static_gauge_messages_Empty_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return gauge.messages.Messages.internal_static_gauge_messages_Empty_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              gauge.messages.Messages.Empty.class, gauge.messages.Messages.Empty.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof gauge.messages.Messages.Empty)) {
+        return super.equals(obj);
+      }
+      gauge.messages.Messages.Empty other = (gauge.messages.Messages.Empty) obj;
+
+      boolean result = true;
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static gauge.messages.Messages.Empty parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.Empty parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.Empty parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Messages.Empty parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(gauge.messages.Messages.Empty prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Empty is a blank response, to be used when there is no return expected.
+     * </pre>
+     *
+     * Protobuf type {@code gauge.messages.Empty}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gauge.messages.Empty)
+        gauge.messages.Messages.EmptyOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return gauge.messages.Messages.internal_static_gauge_messages_Empty_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return gauge.messages.Messages.internal_static_gauge_messages_Empty_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                gauge.messages.Messages.Empty.class, gauge.messages.Messages.Empty.Builder.class);
+      }
+
+      // Construct using gauge.messages.Messages.Empty.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return gauge.messages.Messages.internal_static_gauge_messages_Empty_descriptor;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.Empty getDefaultInstanceForType() {
+        return gauge.messages.Messages.Empty.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.Empty build() {
+        gauge.messages.Messages.Empty result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Messages.Empty buildPartial() {
+        gauge.messages.Messages.Empty result = new gauge.messages.Messages.Empty(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof gauge.messages.Messages.Empty) {
+          return mergeFrom((gauge.messages.Messages.Empty)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(gauge.messages.Messages.Empty other) {
+        if (other == gauge.messages.Messages.Empty.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        gauge.messages.Messages.Empty parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (gauge.messages.Messages.Empty) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:gauge.messages.Empty)
+    }
+
+    // @@protoc_insertion_point(class_scope:gauge.messages.Empty)
+    private static final gauge.messages.Messages.Empty DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new gauge.messages.Messages.Empty();
+    }
+
+    public static gauge.messages.Messages.Empty getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<Empty>
+        PARSER = new com.google.protobuf.AbstractParser<Empty>() {
+      @java.lang.Override
+      public Empty parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Empty(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<Empty> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Empty> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public gauge.messages.Messages.Empty getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface MessageOrBuilder extends
       // @@protoc_insertion_point(interface_extends:gauge.messages.Message)
       com.google.protobuf.MessageOrBuilder {
@@ -33181,6 +39053,56 @@ public final class Messages {
      * <code>.gauge.messages.ImplementationFileGlobPatternResponse implementationFileGlobPatternResponse = 35;</code>
      */
     gauge.messages.Messages.ImplementationFileGlobPatternResponseOrBuilder getImplementationFileGlobPatternResponseOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+     * </pre>
+     *
+     * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+     */
+    boolean hasSuiteExecutionResultItem();
+    /**
+     * <pre>
+     *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+     * </pre>
+     *
+     * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+     */
+    gauge.messages.Messages.SuiteExecutionResultItem getSuiteExecutionResultItem();
+    /**
+     * <pre>
+     *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+     * </pre>
+     *
+     * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+     */
+    gauge.messages.Messages.SuiteExecutionResultItemOrBuilder getSuiteExecutionResultItemOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+     * </pre>
+     *
+     * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+     */
+    boolean hasKeepAlive();
+    /**
+     * <pre>
+     *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+     * </pre>
+     *
+     * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+     */
+    gauge.messages.Messages.KeepAlive getKeepAlive();
+    /**
+     * <pre>
+     *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+     * </pre>
+     *
+     * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+     */
+    gauge.messages.Messages.KeepAliveOrBuilder getKeepAliveOrBuilder();
   }
   /**
    * <pre>
@@ -33191,7 +39113,7 @@ public final class Messages {
    *
    * Protobuf type {@code gauge.messages.Message}
    */
-  public  static class Message extends
+  public  static final class Message extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:gauge.messages.Message)
       MessageOrBuilder {
@@ -33200,7 +39122,7 @@ public final class Messages {
     private Message(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    public Message() {
+    private Message() {
       messageType_ = 0;
       messageId_ = 0L;
     }
@@ -33670,6 +39592,32 @@ public final class Messages {
 
               break;
             }
+            case 290: {
+              gauge.messages.Messages.SuiteExecutionResultItem.Builder subBuilder = null;
+              if (suiteExecutionResultItem_ != null) {
+                subBuilder = suiteExecutionResultItem_.toBuilder();
+              }
+              suiteExecutionResultItem_ = input.readMessage(gauge.messages.Messages.SuiteExecutionResultItem.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(suiteExecutionResultItem_);
+                suiteExecutionResultItem_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 298: {
+              gauge.messages.Messages.KeepAlive.Builder subBuilder = null;
+              if (keepAlive_ != null) {
+                subBuilder = keepAlive_.toBuilder();
+              }
+              keepAlive_ = input.readMessage(gauge.messages.Messages.KeepAlive.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(keepAlive_);
+                keepAlive_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -33839,6 +39787,14 @@ public final class Messages {
        * <code>ImplementationFileGlobPatternResponse = 32;</code>
        */
       ImplementationFileGlobPatternResponse(32),
+      /**
+       * <code>SuiteExecutionResultItem = 33;</code>
+       */
+      SuiteExecutionResultItem(33),
+      /**
+       * <code>KeepAlive = 34;</code>
+       */
+      KeepAlive(34),
       UNRECOGNIZED(-1),
       ;
 
@@ -33974,6 +39930,14 @@ public final class Messages {
        * <code>ImplementationFileGlobPatternResponse = 32;</code>
        */
       public static final int ImplementationFileGlobPatternResponse_VALUE = 32;
+      /**
+       * <code>SuiteExecutionResultItem = 33;</code>
+       */
+      public static final int SuiteExecutionResultItem_VALUE = 33;
+      /**
+       * <code>KeepAlive = 34;</code>
+       */
+      public static final int KeepAlive_VALUE = 34;
 
 
       public final int getNumber() {
@@ -34027,6 +39991,8 @@ public final class Messages {
           case 30: return FileDiff;
           case 31: return ImplementationFileGlobPatternRequest;
           case 32: return ImplementationFileGlobPatternResponse;
+          case 33: return SuiteExecutionResultItem;
+          case 34: return KeepAlive;
           default: return null;
         }
       }
@@ -35199,6 +41165,72 @@ public final class Messages {
       return getImplementationFileGlobPatternResponse();
     }
 
+    public static final int SUITEEXECUTIONRESULTITEM_FIELD_NUMBER = 36;
+    private gauge.messages.Messages.SuiteExecutionResultItem suiteExecutionResultItem_;
+    /**
+     * <pre>
+     *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+     * </pre>
+     *
+     * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+     */
+    public boolean hasSuiteExecutionResultItem() {
+      return suiteExecutionResultItem_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+     * </pre>
+     *
+     * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+     */
+    public gauge.messages.Messages.SuiteExecutionResultItem getSuiteExecutionResultItem() {
+      return suiteExecutionResultItem_ == null ? gauge.messages.Messages.SuiteExecutionResultItem.getDefaultInstance() : suiteExecutionResultItem_;
+    }
+    /**
+     * <pre>
+     *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+     * </pre>
+     *
+     * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+     */
+    public gauge.messages.Messages.SuiteExecutionResultItemOrBuilder getSuiteExecutionResultItemOrBuilder() {
+      return getSuiteExecutionResultItem();
+    }
+
+    public static final int KEEPALIVE_FIELD_NUMBER = 37;
+    private gauge.messages.Messages.KeepAlive keepAlive_;
+    /**
+     * <pre>
+     *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+     * </pre>
+     *
+     * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+     */
+    public boolean hasKeepAlive() {
+      return keepAlive_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+     * </pre>
+     *
+     * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+     */
+    public gauge.messages.Messages.KeepAlive getKeepAlive() {
+      return keepAlive_ == null ? gauge.messages.Messages.KeepAlive.getDefaultInstance() : keepAlive_;
+    }
+    /**
+     * <pre>
+     *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+     * </pre>
+     *
+     * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+     */
+    public gauge.messages.Messages.KeepAliveOrBuilder getKeepAliveOrBuilder() {
+      return getKeepAlive();
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -35317,6 +41349,12 @@ public final class Messages {
       }
       if (implementationFileGlobPatternResponse_ != null) {
         output.writeMessage(35, getImplementationFileGlobPatternResponse());
+      }
+      if (suiteExecutionResultItem_ != null) {
+        output.writeMessage(36, getSuiteExecutionResultItem());
+      }
+      if (keepAlive_ != null) {
+        output.writeMessage(37, getKeepAlive());
       }
       unknownFields.writeTo(output);
     }
@@ -35466,6 +41504,14 @@ public final class Messages {
       if (implementationFileGlobPatternResponse_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(35, getImplementationFileGlobPatternResponse());
+      }
+      if (suiteExecutionResultItem_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(36, getSuiteExecutionResultItem());
+      }
+      if (keepAlive_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(37, getKeepAlive());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -35651,6 +41697,16 @@ public final class Messages {
         result = result && getImplementationFileGlobPatternResponse()
             .equals(other.getImplementationFileGlobPatternResponse());
       }
+      result = result && (hasSuiteExecutionResultItem() == other.hasSuiteExecutionResultItem());
+      if (hasSuiteExecutionResultItem()) {
+        result = result && getSuiteExecutionResultItem()
+            .equals(other.getSuiteExecutionResultItem());
+      }
+      result = result && (hasKeepAlive() == other.hasKeepAlive());
+      if (hasKeepAlive()) {
+        result = result && getKeepAlive()
+            .equals(other.getKeepAlive());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -35798,6 +41854,14 @@ public final class Messages {
       if (hasImplementationFileGlobPatternResponse()) {
         hash = (37 * hash) + IMPLEMENTATIONFILEGLOBPATTERNRESPONSE_FIELD_NUMBER;
         hash = (53 * hash) + getImplementationFileGlobPatternResponse().hashCode();
+      }
+      if (hasSuiteExecutionResultItem()) {
+        hash = (37 * hash) + SUITEEXECUTIONRESULTITEM_FIELD_NUMBER;
+        hash = (53 * hash) + getSuiteExecutionResultItem().hashCode();
+      }
+      if (hasKeepAlive()) {
+        hash = (37 * hash) + KEEPALIVE_FIELD_NUMBER;
+        hash = (53 * hash) + getKeepAlive().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -36140,6 +42204,18 @@ public final class Messages {
           implementationFileGlobPatternResponse_ = null;
           implementationFileGlobPatternResponseBuilder_ = null;
         }
+        if (suiteExecutionResultItemBuilder_ == null) {
+          suiteExecutionResultItem_ = null;
+        } else {
+          suiteExecutionResultItem_ = null;
+          suiteExecutionResultItemBuilder_ = null;
+        }
+        if (keepAliveBuilder_ == null) {
+          keepAlive_ = null;
+        } else {
+          keepAlive_ = null;
+          keepAliveBuilder_ = null;
+        }
         return this;
       }
 
@@ -36333,6 +42409,16 @@ public final class Messages {
         } else {
           result.implementationFileGlobPatternResponse_ = implementationFileGlobPatternResponseBuilder_.build();
         }
+        if (suiteExecutionResultItemBuilder_ == null) {
+          result.suiteExecutionResultItem_ = suiteExecutionResultItem_;
+        } else {
+          result.suiteExecutionResultItem_ = suiteExecutionResultItemBuilder_.build();
+        }
+        if (keepAliveBuilder_ == null) {
+          result.keepAlive_ = keepAlive_;
+        } else {
+          result.keepAlive_ = keepAliveBuilder_.build();
+        }
         onBuilt();
         return result;
       }
@@ -36485,6 +42571,12 @@ public final class Messages {
         }
         if (other.hasImplementationFileGlobPatternResponse()) {
           mergeImplementationFileGlobPatternResponse(other.getImplementationFileGlobPatternResponse());
+        }
+        if (other.hasSuiteExecutionResultItem()) {
+          mergeSuiteExecutionResultItem(other.getSuiteExecutionResultItem());
+        }
+        if (other.hasKeepAlive()) {
+          mergeKeepAlive(other.getKeepAlive());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -41649,6 +47741,312 @@ public final class Messages {
         }
         return implementationFileGlobPatternResponseBuilder_;
       }
+
+      private gauge.messages.Messages.SuiteExecutionResultItem suiteExecutionResultItem_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Messages.SuiteExecutionResultItem, gauge.messages.Messages.SuiteExecutionResultItem.Builder, gauge.messages.Messages.SuiteExecutionResultItemOrBuilder> suiteExecutionResultItemBuilder_;
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public boolean hasSuiteExecutionResultItem() {
+        return suiteExecutionResultItemBuilder_ != null || suiteExecutionResultItem_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public gauge.messages.Messages.SuiteExecutionResultItem getSuiteExecutionResultItem() {
+        if (suiteExecutionResultItemBuilder_ == null) {
+          return suiteExecutionResultItem_ == null ? gauge.messages.Messages.SuiteExecutionResultItem.getDefaultInstance() : suiteExecutionResultItem_;
+        } else {
+          return suiteExecutionResultItemBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public Builder setSuiteExecutionResultItem(gauge.messages.Messages.SuiteExecutionResultItem value) {
+        if (suiteExecutionResultItemBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          suiteExecutionResultItem_ = value;
+          onChanged();
+        } else {
+          suiteExecutionResultItemBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public Builder setSuiteExecutionResultItem(
+          gauge.messages.Messages.SuiteExecutionResultItem.Builder builderForValue) {
+        if (suiteExecutionResultItemBuilder_ == null) {
+          suiteExecutionResultItem_ = builderForValue.build();
+          onChanged();
+        } else {
+          suiteExecutionResultItemBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public Builder mergeSuiteExecutionResultItem(gauge.messages.Messages.SuiteExecutionResultItem value) {
+        if (suiteExecutionResultItemBuilder_ == null) {
+          if (suiteExecutionResultItem_ != null) {
+            suiteExecutionResultItem_ =
+              gauge.messages.Messages.SuiteExecutionResultItem.newBuilder(suiteExecutionResultItem_).mergeFrom(value).buildPartial();
+          } else {
+            suiteExecutionResultItem_ = value;
+          }
+          onChanged();
+        } else {
+          suiteExecutionResultItemBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public Builder clearSuiteExecutionResultItem() {
+        if (suiteExecutionResultItemBuilder_ == null) {
+          suiteExecutionResultItem_ = null;
+          onChanged();
+        } else {
+          suiteExecutionResultItem_ = null;
+          suiteExecutionResultItemBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public gauge.messages.Messages.SuiteExecutionResultItem.Builder getSuiteExecutionResultItemBuilder() {
+        
+        onChanged();
+        return getSuiteExecutionResultItemFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      public gauge.messages.Messages.SuiteExecutionResultItemOrBuilder getSuiteExecutionResultItemOrBuilder() {
+        if (suiteExecutionResultItemBuilder_ != null) {
+          return suiteExecutionResultItemBuilder_.getMessageOrBuilder();
+        } else {
+          return suiteExecutionResultItem_ == null ?
+              gauge.messages.Messages.SuiteExecutionResultItem.getDefaultInstance() : suiteExecutionResultItem_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; [SuiteExecutionResult ](#gauge.messages.SuiteExecutionResult )
+       * </pre>
+       *
+       * <code>.gauge.messages.SuiteExecutionResultItem suiteExecutionResultItem = 36;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Messages.SuiteExecutionResultItem, gauge.messages.Messages.SuiteExecutionResultItem.Builder, gauge.messages.Messages.SuiteExecutionResultItemOrBuilder> 
+          getSuiteExecutionResultItemFieldBuilder() {
+        if (suiteExecutionResultItemBuilder_ == null) {
+          suiteExecutionResultItemBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Messages.SuiteExecutionResultItem, gauge.messages.Messages.SuiteExecutionResultItem.Builder, gauge.messages.Messages.SuiteExecutionResultItemOrBuilder>(
+                  getSuiteExecutionResultItem(),
+                  getParentForChildren(),
+                  isClean());
+          suiteExecutionResultItem_ = null;
+        }
+        return suiteExecutionResultItemBuilder_;
+      }
+
+      private gauge.messages.Messages.KeepAlive keepAlive_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Messages.KeepAlive, gauge.messages.Messages.KeepAlive.Builder, gauge.messages.Messages.KeepAliveOrBuilder> keepAliveBuilder_;
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public boolean hasKeepAlive() {
+        return keepAliveBuilder_ != null || keepAlive_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public gauge.messages.Messages.KeepAlive getKeepAlive() {
+        if (keepAliveBuilder_ == null) {
+          return keepAlive_ == null ? gauge.messages.Messages.KeepAlive.getDefaultInstance() : keepAlive_;
+        } else {
+          return keepAliveBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public Builder setKeepAlive(gauge.messages.Messages.KeepAlive value) {
+        if (keepAliveBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          keepAlive_ = value;
+          onChanged();
+        } else {
+          keepAliveBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public Builder setKeepAlive(
+          gauge.messages.Messages.KeepAlive.Builder builderForValue) {
+        if (keepAliveBuilder_ == null) {
+          keepAlive_ = builderForValue.build();
+          onChanged();
+        } else {
+          keepAliveBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public Builder mergeKeepAlive(gauge.messages.Messages.KeepAlive value) {
+        if (keepAliveBuilder_ == null) {
+          if (keepAlive_ != null) {
+            keepAlive_ =
+              gauge.messages.Messages.KeepAlive.newBuilder(keepAlive_).mergeFrom(value).buildPartial();
+          } else {
+            keepAlive_ = value;
+          }
+          onChanged();
+        } else {
+          keepAliveBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public Builder clearKeepAlive() {
+        if (keepAliveBuilder_ == null) {
+          keepAlive_ = null;
+          onChanged();
+        } else {
+          keepAlive_ = null;
+          keepAliveBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public gauge.messages.Messages.KeepAlive.Builder getKeepAliveBuilder() {
+        
+        onChanged();
+        return getKeepAliveFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      public gauge.messages.Messages.KeepAliveOrBuilder getKeepAliveOrBuilder() {
+        if (keepAliveBuilder_ != null) {
+          return keepAliveBuilder_.getMessageOrBuilder();
+        } else {
+          return keepAlive_ == null ?
+              gauge.messages.Messages.KeepAlive.getDefaultInstance() : keepAlive_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; [KeepAlive ](#gauge.messages.KeepAlive )
+       * </pre>
+       *
+       * <code>.gauge.messages.KeepAlive keepAlive = 37;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Messages.KeepAlive, gauge.messages.Messages.KeepAlive.Builder, gauge.messages.Messages.KeepAliveOrBuilder> 
+          getKeepAliveFieldBuilder() {
+        if (keepAliveBuilder_ == null) {
+          keepAliveBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Messages.KeepAlive, gauge.messages.Messages.KeepAlive.Builder, gauge.messages.Messages.KeepAliveOrBuilder>(
+                  getKeepAlive(),
+                  getParentForChildren(),
+                  isClean());
+          keepAlive_ = null;
+        }
+        return keepAliveBuilder_;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -41753,6 +48151,11 @@ public final class Messages {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_gauge_messages_StepExecutionEndingRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gauge_messages_ExecutionArg_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_gauge_messages_ExecutionArg_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_gauge_messages_ExecutionInfo_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -41792,6 +48195,11 @@ public final class Messages {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_gauge_messages_SuiteExecutionResult_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gauge_messages_SuiteExecutionResultItem_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_gauge_messages_SuiteExecutionResultItem_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_gauge_messages_StepNamesRequest_descriptor;
   private static final 
@@ -41908,6 +48316,16 @@ public final class Messages {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_gauge_messages_FileDiff_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gauge_messages_KeepAlive_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_gauge_messages_KeepAlive_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gauge_messages_Empty_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_gauge_messages_Empty_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_gauge_messages_Message_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -41924,181 +48342,204 @@ public final class Messages {
       "\n\016messages.proto\022\016gauge.messages\032\nspec.p" +
       "roto\"\024\n\022KillProcessRequest\"X\n\027ExecutionS" +
       "tatusResponse\022=\n\017executionResult\030\001 \001(\0132$" +
-      ".gauge.messages.ProtoExecutionResult\"W\n\030" +
-      "ExecutionStartingRequest\022;\n\024currentExecu" +
-      "tionInfo\030\001 \001(\0132\035.gauge.messages.Executio" +
-      "nInfo\"U\n\026ExecutionEndingRequest\022;\n\024curre" +
-      "ntExecutionInfo\030\001 \001(\0132\035.gauge.messages.E" +
-      "xecutionInfo\"[\n\034SpecExecutionStartingReq" +
-      "uest\022;\n\024currentExecutionInfo\030\001 \001(\0132\035.gau" +
-      "ge.messages.ExecutionInfo\"Y\n\032SpecExecuti" +
-      "onEndingRequest\022;\n\024currentExecutionInfo\030" +
-      "\001 \001(\0132\035.gauge.messages.ExecutionInfo\"_\n " +
-      "ScenarioExecutionStartingRequest\022;\n\024curr" +
-      "entExecutionInfo\030\001 \001(\0132\035.gauge.messages." +
-      "ExecutionInfo\"]\n\036ScenarioExecutionEnding" +
-      "Request\022;\n\024currentExecutionInfo\030\001 \001(\0132\035." +
-      "gauge.messages.ExecutionInfo\"[\n\034StepExec" +
-      "utionStartingRequest\022;\n\024currentExecution" +
-      "Info\030\001 \001(\0132\035.gauge.messages.ExecutionInf" +
-      "o\"Y\n\032StepExecutionEndingRequest\022;\n\024curre" +
-      "ntExecutionInfo\030\001 \001(\0132\035.gauge.messages.E" +
-      "xecutionInfo\"\270\001\n\rExecutionInfo\022-\n\013curren" +
-      "tSpec\030\001 \001(\0132\030.gauge.messages.SpecInfo\0225\n" +
-      "\017currentScenario\030\002 \001(\0132\034.gauge.messages." +
-      "ScenarioInfo\022-\n\013currentStep\030\003 \001(\0132\030.gaug" +
-      "e.messages.StepInfo\022\022\n\nstacktrace\030\004 \001(\t\"" +
-      "J\n\010SpecInfo\022\014\n\004name\030\001 \001(\t\022\020\n\010fileName\030\002 " +
-      "\001(\t\022\020\n\010isFailed\030\003 \001(\010\022\014\n\004tags\030\004 \003(\t\"<\n\014S" +
-      "cenarioInfo\022\014\n\004name\030\001 \001(\t\022\020\n\010isFailed\030\002 " +
-      "\001(\010\022\014\n\004tags\030\003 \003(\t\"x\n\010StepInfo\0220\n\004step\030\001 " +
-      "\001(\0132\".gauge.messages.ExecuteStepRequest\022" +
-      "\020\n\010isFailed\030\002 \001(\010\022\022\n\nstackTrace\030\003 \001(\t\022\024\n" +
-      "\014errorMessage\030\004 \001(\t\"\214\001\n\022ExecuteStepReque" +
-      "st\022\026\n\016actualStepText\030\001 \001(\t\022\026\n\016parsedStep" +
-      "Text\030\002 \001(\t\022\027\n\017scenarioFailing\030\003 \001(\010\022-\n\np" +
-      "arameters\030\004 \003(\0132\031.gauge.messages.Paramet" +
-      "er\"v\n\023StepValidateRequest\022\020\n\010stepText\030\001 " +
-      "\001(\t\022\032\n\022numberOfParameters\030\002 \001(\005\0221\n\tstepV" +
-      "alue\030\003 \001(\0132\036.gauge.messages.ProtoStepVal" +
-      "ue\"\347\001\n\024StepValidateResponse\022\017\n\007isValid\030\001" +
-      " \001(\010\022\024\n\014errorMessage\030\002 \001(\t\022A\n\terrorType\030" +
-      "\003 \001(\0162..gauge.messages.StepValidateRespo" +
-      "nse.ErrorType\022\022\n\nsuggestion\030\004 \001(\t\"Q\n\tErr" +
-      "orType\022!\n\035STEP_IMPLEMENTATION_NOT_FOUND\020" +
-      "\000\022!\n\035DUPLICATE_STEP_IMPLEMENTATION\020\001\"M\n\024" +
-      "SuiteExecutionResult\0225\n\013suiteResult\030\001 \001(" +
-      "\0132 .gauge.messages.ProtoSuiteResult\"\022\n\020S" +
-      "tepNamesRequest\"\"\n\021StepNamesResponse\022\r\n\005" +
-      "steps\030\001 \003(\t\"\036\n\034ScenarioDataStoreInitRequ" +
-      "est\"\032\n\030SpecDataStoreInitRequest\"\033\n\031Suite" +
-      "DataStoreInitRequest\"=\n\021ParameterPositio" +
-      "n\022\023\n\013oldPosition\030\001 \001(\005\022\023\n\013newPosition\030\002 " +
-      "\001(\005\"\315\001\n\017RefactorRequest\0224\n\014oldStepValue\030" +
-      "\001 \001(\0132\036.gauge.messages.ProtoStepValue\0224\n" +
-      "\014newStepValue\030\002 \001(\0132\036.gauge.messages.Pro" +
-      "toStepValue\0229\n\016paramPositions\030\003 \003(\0132!.ga" +
-      "uge.messages.ParameterPosition\022\023\n\013saveCh" +
-      "anges\030\004 \001(\010\"a\n\013FileChanges\022\020\n\010fileName\030\001" +
-      " \001(\t\022\027\n\013fileContent\030\002 \001(\tB\002\030\001\022\'\n\005diffs\030\003" +
-      " \003(\0132\030.gauge.messages.TextDiff\"z\n\020Refact" +
-      "orResponse\022\017\n\007success\030\001 \001(\010\022\r\n\005error\030\002 \001" +
-      "(\t\022\024\n\014filesChanged\030\003 \003(\t\0220\n\013fileChanges\030" +
-      "\004 \003(\0132\033.gauge.messages.FileChanges\"$\n\017St" +
-      "epNameRequest\022\021\n\tstepValue\030\001 \001(\t\"\203\001\n\020Ste" +
-      "pNameResponse\022\025\n\risStepPresent\030\001 \001(\010\022\020\n\010" +
-      "stepName\030\002 \003(\t\022\020\n\010hasAlias\030\003 \001(\010\022\020\n\010file" +
-      "Name\030\004 \001(\t\022\"\n\004span\030\005 \001(\0132\024.gauge.message" +
-      "s.Span\"-\n\032UnsupportedMessageResponse\022\017\n\007" +
-      "message\030\001 \001(\t\"\321\001\n\020CacheFileRequest\022\017\n\007co" +
-      "ntent\030\001 \001(\t\022\020\n\010filePath\030\002 \001(\t\022\020\n\010isClose" +
-      "d\030\003 \001(\010\022;\n\006status\030\004 \001(\0162+.gauge.messages" +
-      ".CacheFileRequest.FileStatus\"K\n\nFileStat" +
-      "us\022\013\n\007CHANGED\020\000\022\n\n\006CLOSED\020\001\022\013\n\007CREATED\020\002" +
-      "\022\013\n\007DELETED\020\003\022\n\n\006OPENED\020\004\"(\n\024StepPositio" +
-      "nsRequest\022\020\n\010filePath\030\001 \001(\t\"\270\001\n\025StepPosi" +
-      "tionsResponse\022I\n\rstepPositions\030\001 \003(\01322.g" +
-      "auge.messages.StepPositionsResponse.Step" +
-      "Position\022\r\n\005error\030\002 \001(\t\032E\n\014StepPosition\022" +
-      "\021\n\tstepValue\030\001 \001(\t\022\"\n\004span\030\002 \001(\0132\024.gauge" +
-      ".messages.Span\"&\n$ImplementationFileGlob" +
-      "PatternRequest\"=\n%ImplementationFileGlob" +
-      "PatternResponse\022\024\n\014globPatterns\030\001 \003(\t\"\037\n" +
-      "\035ImplementationFileListRequest\"A\n\036Implem" +
-      "entationFileListResponse\022\037\n\027implementati" +
-      "onFilePaths\030\001 \003(\t\"N\n\035StubImplementationC" +
-      "odeRequest\022\036\n\026implementationFilePath\030\001 \001" +
-      "(\t\022\r\n\005codes\030\002 \003(\t\"?\n\010TextDiff\022\"\n\004span\030\001 " +
-      "\001(\0132\024.gauge.messages.Span\022\017\n\007content\030\002 \001" +
-      "(\t\"I\n\010FileDiff\022\020\n\010filePath\030\001 \001(\t\022+\n\ttext" +
-      "Diffs\030\002 \003(\0132\030.gauge.messages.TextDiff\"\326\032" +
-      "\n\007Message\0228\n\013messageType\030\001 \001(\0162#.gauge.m" +
-      "essages.Message.MessageType\022\021\n\tmessageId" +
-      "\030\002 \001(\003\022J\n\030executionStartingRequest\030\003 \001(\013" +
-      "2(.gauge.messages.ExecutionStartingReque" +
-      "st\022R\n\034specExecutionStartingRequest\030\004 \001(\013" +
-      "2,.gauge.messages.SpecExecutionStartingR" +
-      "equest\022N\n\032specExecutionEndingRequest\030\005 \001" +
-      "(\0132*.gauge.messages.SpecExecutionEndingR" +
-      "equest\022Z\n scenarioExecutionStartingReque" +
-      "st\030\006 \001(\01320.gauge.messages.ScenarioExecut" +
-      "ionStartingRequest\022V\n\036scenarioExecutionE" +
-      "ndingRequest\030\007 \001(\0132..gauge.messages.Scen" +
-      "arioExecutionEndingRequest\022R\n\034stepExecut" +
-      "ionStartingRequest\030\010 \001(\0132,.gauge.message" +
-      "s.StepExecutionStartingRequest\022N\n\032stepEx" +
-      "ecutionEndingRequest\030\t \001(\0132*.gauge.messa" +
-      "ges.StepExecutionEndingRequest\022>\n\022execut" +
-      "eStepRequest\030\n \001(\0132\".gauge.messages.Exec" +
-      "uteStepRequest\022F\n\026executionEndingRequest" +
-      "\030\013 \001(\0132&.gauge.messages.ExecutionEndingR" +
-      "equest\022@\n\023stepValidateRequest\030\014 \001(\0132#.ga" +
-      "uge.messages.StepValidateRequest\022B\n\024step" +
-      "ValidateResponse\030\r \001(\0132$.gauge.messages." +
-      "StepValidateResponse\022H\n\027executionStatusR" +
-      "esponse\030\016 \001(\0132\'.gauge.messages.Execution" +
-      "StatusResponse\022:\n\020stepNamesRequest\030\017 \001(\013" +
-      "2 .gauge.messages.StepNamesRequest\022<\n\021st" +
-      "epNamesResponse\030\020 \001(\0132!.gauge.messages.S" +
-      "tepNamesResponse\022B\n\024suiteExecutionResult" +
-      "\030\021 \001(\0132$.gauge.messages.SuiteExecutionRe" +
-      "sult\022>\n\022killProcessRequest\030\022 \001(\0132\".gauge" +
-      ".messages.KillProcessRequest\022R\n\034scenario" +
-      "DataStoreInitRequest\030\023 \001(\0132,.gauge.messa" +
-      "ges.ScenarioDataStoreInitRequest\022J\n\030spec" +
-      "DataStoreInitRequest\030\024 \001(\0132(.gauge.messa" +
-      "ges.SpecDataStoreInitRequest\022L\n\031suiteDat" +
-      "aStoreInitRequest\030\025 \001(\0132).gauge.messages" +
-      ".SuiteDataStoreInitRequest\0228\n\017stepNameRe" +
-      "quest\030\026 \001(\0132\037.gauge.messages.StepNameReq" +
-      "uest\022:\n\020stepNameResponse\030\027 \001(\0132 .gauge.m" +
-      "essages.StepNameResponse\0228\n\017refactorRequ" +
-      "est\030\030 \001(\0132\037.gauge.messages.RefactorReque" +
-      "st\022:\n\020refactorResponse\030\031 \001(\0132 .gauge.mes" +
-      "sages.RefactorResponse\022N\n\032unsupportedMes" +
-      "sageResponse\030\032 \001(\0132*.gauge.messages.Unsu" +
-      "pportedMessageResponse\022:\n\020cacheFileReque" +
-      "st\030\033 \001(\0132 .gauge.messages.CacheFileReque" +
-      "st\022B\n\024stepPositionsRequest\030\034 \001(\0132$.gauge" +
-      ".messages.StepPositionsRequest\022D\n\025stepPo" +
-      "sitionsResponse\030\035 \001(\0132%.gauge.messages.S" +
-      "tepPositionsResponse\022T\n\035implementationFi" +
-      "leListRequest\030\036 \001(\0132-.gauge.messages.Imp" +
-      "lementationFileListRequest\022V\n\036implementa" +
-      "tionFileListResponse\030\037 \001(\0132..gauge.messa" +
-      "ges.ImplementationFileListResponse\022T\n\035st" +
-      "ubImplementationCodeRequest\030  \001(\0132-.gaug" +
-      "e.messages.StubImplementationCodeRequest" +
-      "\022*\n\010fileDiff\030! \001(\0132\030.gauge.messages.File" +
-      "Diff\022b\n$implementationFileGlobPatternReq" +
-      "uest\030\" \001(\01324.gauge.messages.Implementati" +
-      "onFileGlobPatternRequest\022d\n%implementati" +
-      "onFileGlobPatternResponse\030# \001(\01325.gauge." +
-      "messages.ImplementationFileGlobPatternRe" +
-      "sponse\"\365\006\n\013MessageType\022\025\n\021ExecutionStart" +
-      "ing\020\000\022\031\n\025SpecExecutionStarting\020\001\022\027\n\023Spec" +
-      "ExecutionEnding\020\002\022\035\n\031ScenarioExecutionSt" +
-      "arting\020\003\022\033\n\027ScenarioExecutionEnding\020\004\022\031\n" +
-      "\025StepExecutionStarting\020\005\022\027\n\023StepExecutio" +
-      "nEnding\020\006\022\017\n\013ExecuteStep\020\007\022\023\n\017ExecutionE" +
-      "nding\020\010\022\027\n\023StepValidateRequest\020\t\022\030\n\024Step" +
-      "ValidateResponse\020\n\022\033\n\027ExecutionStatusRes" +
-      "ponse\020\013\022\024\n\020StepNamesRequest\020\014\022\025\n\021StepNam" +
-      "esResponse\020\r\022\026\n\022KillProcessRequest\020\016\022\030\n\024" +
-      "SuiteExecutionResult\020\017\022\031\n\025ScenarioDataSt" +
-      "oreInit\020\020\022\025\n\021SpecDataStoreInit\020\021\022\026\n\022Suit" +
-      "eDataStoreInit\020\022\022\023\n\017StepNameRequest\020\023\022\024\n" +
-      "\020StepNameResponse\020\024\022\023\n\017RefactorRequest\020\025" +
-      "\022\024\n\020RefactorResponse\020\026\022\036\n\032UnsupportedMes" +
-      "sageResponse\020\027\022\024\n\020CacheFileRequest\020\030\022\030\n\024" +
-      "StepPositionsRequest\020\031\022\031\n\025StepPositionsR" +
-      "esponse\020\032\022!\n\035ImplementationFileListReque" +
-      "st\020\033\022\"\n\036ImplementationFileListResponse\020\034" +
-      "\022!\n\035StubImplementationCodeRequest\020\035\022\014\n\010F" +
-      "ileDiff\020\036\022(\n$ImplementationFileGlobPatte" +
-      "rnRequest\020\037\022)\n%ImplementationFileGlobPat" +
-      "ternResponse\020 B\021\252\002\016Gauge.Messagesb\006proto" +
-      "3"
+      ".gauge.messages.ProtoExecutionResult\"\216\001\n" +
+      "\030ExecutionStartingRequest\022;\n\024currentExec" +
+      "utionInfo\030\001 \001(\0132\035.gauge.messages.Executi" +
+      "onInfo\0225\n\013suiteResult\030\002 \001(\0132 .gauge.mess" +
+      "ages.ProtoSuiteResult\"\214\001\n\026ExecutionEndin" +
+      "gRequest\022;\n\024currentExecutionInfo\030\001 \001(\0132\035" +
+      ".gauge.messages.ExecutionInfo\0225\n\013suiteRe" +
+      "sult\030\002 \001(\0132 .gauge.messages.ProtoSuiteRe" +
+      "sult\"\220\001\n\034SpecExecutionStartingRequest\022;\n" +
+      "\024currentExecutionInfo\030\001 \001(\0132\035.gauge.mess" +
+      "ages.ExecutionInfo\0223\n\nspecResult\030\002 \001(\0132\037" +
+      ".gauge.messages.ProtoSpecResult\"\216\001\n\032Spec" +
+      "ExecutionEndingRequest\022;\n\024currentExecuti" +
+      "onInfo\030\001 \001(\0132\035.gauge.messages.ExecutionI" +
+      "nfo\0223\n\nspecResult\030\002 \001(\0132\037.gauge.messages" +
+      ".ProtoSpecResult\"\234\001\n ScenarioExecutionSt" +
+      "artingRequest\022;\n\024currentExecutionInfo\030\001 " +
+      "\001(\0132\035.gauge.messages.ExecutionInfo\022;\n\016sc" +
+      "enarioResult\030\002 \001(\0132#.gauge.messages.Prot" +
+      "oScenarioResult\"\232\001\n\036ScenarioExecutionEnd" +
+      "ingRequest\022;\n\024currentExecutionInfo\030\001 \001(\013" +
+      "2\035.gauge.messages.ExecutionInfo\022;\n\016scena" +
+      "rioResult\030\002 \001(\0132#.gauge.messages.ProtoSc" +
+      "enarioResult\"\220\001\n\034StepExecutionStartingRe" +
+      "quest\022;\n\024currentExecutionInfo\030\001 \001(\0132\035.ga" +
+      "uge.messages.ExecutionInfo\0223\n\nstepResult" +
+      "\030\002 \001(\0132\037.gauge.messages.ProtoStepResult\"" +
+      "\216\001\n\032StepExecutionEndingRequest\022;\n\024curren" +
+      "tExecutionInfo\030\001 \001(\0132\035.gauge.messages.Ex" +
+      "ecutionInfo\0223\n\nstepResult\030\002 \001(\0132\037.gauge." +
+      "messages.ProtoStepResult\"3\n\014ExecutionArg" +
+      "\022\020\n\010flagName\030\001 \001(\t\022\021\n\tflagValue\030\002 \003(\t\"\266\002" +
+      "\n\rExecutionInfo\022-\n\013currentSpec\030\001 \001(\0132\030.g" +
+      "auge.messages.SpecInfo\0225\n\017currentScenari" +
+      "o\030\002 \001(\0132\034.gauge.messages.ScenarioInfo\022-\n" +
+      "\013currentStep\030\003 \001(\0132\030.gauge.messages.Step" +
+      "Info\022\022\n\nstacktrace\030\004 \001(\t\022\023\n\013projectName\030" +
+      "\005 \001(\t\0223\n\rExecutionArgs\030\006 \003(\0132\034.gauge.mes" +
+      "sages.ExecutionArg\022 \n\030numberOfExecutionS" +
+      "treams\030\007 \001(\005\022\020\n\010runnerId\030\010 \001(\005\"J\n\010SpecIn" +
+      "fo\022\014\n\004name\030\001 \001(\t\022\020\n\010fileName\030\002 \001(\t\022\020\n\010is" +
+      "Failed\030\003 \001(\010\022\014\n\004tags\030\004 \003(\t\"<\n\014ScenarioIn" +
+      "fo\022\014\n\004name\030\001 \001(\t\022\020\n\010isFailed\030\002 \001(\010\022\014\n\004ta" +
+      "gs\030\003 \003(\t\"x\n\010StepInfo\0220\n\004step\030\001 \001(\0132\".gau" +
+      "ge.messages.ExecuteStepRequest\022\020\n\010isFail" +
+      "ed\030\002 \001(\010\022\022\n\nstackTrace\030\003 \001(\t\022\024\n\014errorMes" +
+      "sage\030\004 \001(\t\"\214\001\n\022ExecuteStepRequest\022\026\n\016act" +
+      "ualStepText\030\001 \001(\t\022\026\n\016parsedStepText\030\002 \001(" +
+      "\t\022\027\n\017scenarioFailing\030\003 \001(\010\022-\n\nparameters" +
+      "\030\004 \003(\0132\031.gauge.messages.Parameter\"v\n\023Ste" +
+      "pValidateRequest\022\020\n\010stepText\030\001 \001(\t\022\032\n\022nu" +
+      "mberOfParameters\030\002 \001(\005\0221\n\tstepValue\030\003 \001(" +
+      "\0132\036.gauge.messages.ProtoStepValue\"\347\001\n\024St" +
+      "epValidateResponse\022\017\n\007isValid\030\001 \001(\010\022\024\n\014e" +
+      "rrorMessage\030\002 \001(\t\022A\n\terrorType\030\003 \001(\0162..g" +
+      "auge.messages.StepValidateResponse.Error" +
+      "Type\022\022\n\nsuggestion\030\004 \001(\t\"Q\n\tErrorType\022!\n" +
+      "\035STEP_IMPLEMENTATION_NOT_FOUND\020\000\022!\n\035DUPL" +
+      "ICATE_STEP_IMPLEMENTATION\020\001\"M\n\024SuiteExec" +
+      "utionResult\0225\n\013suiteResult\030\001 \001(\0132 .gauge" +
+      ".messages.ProtoSuiteResult\"I\n\030SuiteExecu" +
+      "tionResultItem\022-\n\nresultItem\030\001 \001(\0132\031.gau" +
+      "ge.messages.ProtoItem\"\022\n\020StepNamesReques" +
+      "t\"\"\n\021StepNamesResponse\022\r\n\005steps\030\001 \003(\t\"\036\n" +
+      "\034ScenarioDataStoreInitRequest\"\032\n\030SpecDat" +
+      "aStoreInitRequest\"\033\n\031SuiteDataStoreInitR" +
+      "equest\"=\n\021ParameterPosition\022\023\n\013oldPositi" +
+      "on\030\001 \001(\005\022\023\n\013newPosition\030\002 \001(\005\"\315\001\n\017Refact" +
+      "orRequest\0224\n\014oldStepValue\030\001 \001(\0132\036.gauge." +
+      "messages.ProtoStepValue\0224\n\014newStepValue\030" +
+      "\002 \001(\0132\036.gauge.messages.ProtoStepValue\0229\n" +
+      "\016paramPositions\030\003 \003(\0132!.gauge.messages.P" +
+      "arameterPosition\022\023\n\013saveChanges\030\004 \001(\010\"a\n" +
+      "\013FileChanges\022\020\n\010fileName\030\001 \001(\t\022\027\n\013fileCo" +
+      "ntent\030\002 \001(\tB\002\030\001\022\'\n\005diffs\030\003 \003(\0132\030.gauge.m" +
+      "essages.TextDiff\"z\n\020RefactorResponse\022\017\n\007" +
+      "success\030\001 \001(\010\022\r\n\005error\030\002 \001(\t\022\024\n\014filesCha" +
+      "nged\030\003 \003(\t\0220\n\013fileChanges\030\004 \003(\0132\033.gauge." +
+      "messages.FileChanges\"$\n\017StepNameRequest\022" +
+      "\021\n\tstepValue\030\001 \001(\t\"\203\001\n\020StepNameResponse\022" +
+      "\025\n\risStepPresent\030\001 \001(\010\022\020\n\010stepName\030\002 \003(\t" +
+      "\022\020\n\010hasAlias\030\003 \001(\010\022\020\n\010fileName\030\004 \001(\t\022\"\n\004" +
+      "span\030\005 \001(\0132\024.gauge.messages.Span\"-\n\032Unsu" +
+      "pportedMessageResponse\022\017\n\007message\030\001 \001(\t\"" +
+      "\321\001\n\020CacheFileRequest\022\017\n\007content\030\001 \001(\t\022\020\n" +
+      "\010filePath\030\002 \001(\t\022\020\n\010isClosed\030\003 \001(\010\022;\n\006sta" +
+      "tus\030\004 \001(\0162+.gauge.messages.CacheFileRequ" +
+      "est.FileStatus\"K\n\nFileStatus\022\013\n\007CHANGED\020" +
+      "\000\022\n\n\006CLOSED\020\001\022\013\n\007CREATED\020\002\022\013\n\007DELETED\020\003\022" +
+      "\n\n\006OPENED\020\004\"(\n\024StepPositionsRequest\022\020\n\010f" +
+      "ilePath\030\001 \001(\t\"\270\001\n\025StepPositionsResponse\022" +
+      "I\n\rstepPositions\030\001 \003(\01322.gauge.messages." +
+      "StepPositionsResponse.StepPosition\022\r\n\005er" +
+      "ror\030\002 \001(\t\032E\n\014StepPosition\022\021\n\tstepValue\030\001" +
+      " \001(\t\022\"\n\004span\030\002 \001(\0132\024.gauge.messages.Span" +
+      "\"&\n$ImplementationFileGlobPatternRequest" +
+      "\"=\n%ImplementationFileGlobPatternRespons" +
+      "e\022\024\n\014globPatterns\030\001 \003(\t\"\037\n\035Implementatio" +
+      "nFileListRequest\"A\n\036ImplementationFileLi" +
+      "stResponse\022\037\n\027implementationFilePaths\030\001 " +
+      "\003(\t\"N\n\035StubImplementationCodeRequest\022\036\n\026" +
+      "implementationFilePath\030\001 \001(\t\022\r\n\005codes\030\002 " +
+      "\003(\t\"?\n\010TextDiff\022\"\n\004span\030\001 \001(\0132\024.gauge.me" +
+      "ssages.Span\022\017\n\007content\030\002 \001(\t\"I\n\010FileDiff" +
+      "\022\020\n\010filePath\030\001 \001(\t\022+\n\ttextDiffs\030\002 \003(\0132\030." +
+      "gauge.messages.TextDiff\"\035\n\tKeepAlive\022\020\n\010" +
+      "pluginId\030\001 \001(\t\"\007\n\005Empty\"\375\033\n\007Message\0228\n\013m" +
+      "essageType\030\001 \001(\0162#.gauge.messages.Messag" +
+      "e.MessageType\022\021\n\tmessageId\030\002 \001(\003\022J\n\030exec" +
+      "utionStartingRequest\030\003 \001(\0132(.gauge.messa" +
+      "ges.ExecutionStartingRequest\022R\n\034specExec" +
+      "utionStartingRequest\030\004 \001(\0132,.gauge.messa" +
+      "ges.SpecExecutionStartingRequest\022N\n\032spec" +
+      "ExecutionEndingRequest\030\005 \001(\0132*.gauge.mes" +
+      "sages.SpecExecutionEndingRequest\022Z\n scen" +
+      "arioExecutionStartingRequest\030\006 \001(\01320.gau" +
+      "ge.messages.ScenarioExecutionStartingReq" +
+      "uest\022V\n\036scenarioExecutionEndingRequest\030\007" +
+      " \001(\0132..gauge.messages.ScenarioExecutionE" +
+      "ndingRequest\022R\n\034stepExecutionStartingReq" +
+      "uest\030\010 \001(\0132,.gauge.messages.StepExecutio" +
+      "nStartingRequest\022N\n\032stepExecutionEndingR" +
+      "equest\030\t \001(\0132*.gauge.messages.StepExecut" +
+      "ionEndingRequest\022>\n\022executeStepRequest\030\n" +
+      " \001(\0132\".gauge.messages.ExecuteStepRequest" +
+      "\022F\n\026executionEndingRequest\030\013 \001(\0132&.gauge" +
+      ".messages.ExecutionEndingRequest\022@\n\023step" +
+      "ValidateRequest\030\014 \001(\0132#.gauge.messages.S" +
+      "tepValidateRequest\022B\n\024stepValidateRespon" +
+      "se\030\r \001(\0132$.gauge.messages.StepValidateRe" +
+      "sponse\022H\n\027executionStatusResponse\030\016 \001(\0132" +
+      "\'.gauge.messages.ExecutionStatusResponse" +
+      "\022:\n\020stepNamesRequest\030\017 \001(\0132 .gauge.messa" +
+      "ges.StepNamesRequest\022<\n\021stepNamesRespons" +
+      "e\030\020 \001(\0132!.gauge.messages.StepNamesRespon" +
+      "se\022B\n\024suiteExecutionResult\030\021 \001(\0132$.gauge" +
+      ".messages.SuiteExecutionResult\022>\n\022killPr" +
+      "ocessRequest\030\022 \001(\0132\".gauge.messages.Kill" +
+      "ProcessRequest\022R\n\034scenarioDataStoreInitR" +
+      "equest\030\023 \001(\0132,.gauge.messages.ScenarioDa" +
+      "taStoreInitRequest\022J\n\030specDataStoreInitR" +
+      "equest\030\024 \001(\0132(.gauge.messages.SpecDataSt" +
+      "oreInitRequest\022L\n\031suiteDataStoreInitRequ" +
+      "est\030\025 \001(\0132).gauge.messages.SuiteDataStor" +
+      "eInitRequest\0228\n\017stepNameRequest\030\026 \001(\0132\037." +
+      "gauge.messages.StepNameRequest\022:\n\020stepNa" +
+      "meResponse\030\027 \001(\0132 .gauge.messages.StepNa" +
+      "meResponse\0228\n\017refactorRequest\030\030 \001(\0132\037.ga" +
+      "uge.messages.RefactorRequest\022:\n\020refactor" +
+      "Response\030\031 \001(\0132 .gauge.messages.Refactor" +
+      "Response\022N\n\032unsupportedMessageResponse\030\032" +
+      " \001(\0132*.gauge.messages.UnsupportedMessage" +
+      "Response\022:\n\020cacheFileRequest\030\033 \001(\0132 .gau" +
+      "ge.messages.CacheFileRequest\022B\n\024stepPosi" +
+      "tionsRequest\030\034 \001(\0132$.gauge.messages.Step" +
+      "PositionsRequest\022D\n\025stepPositionsRespons" +
+      "e\030\035 \001(\0132%.gauge.messages.StepPositionsRe" +
+      "sponse\022T\n\035implementationFileListRequest\030" +
+      "\036 \001(\0132-.gauge.messages.ImplementationFil" +
+      "eListRequest\022V\n\036implementationFileListRe" +
+      "sponse\030\037 \001(\0132..gauge.messages.Implementa" +
+      "tionFileListResponse\022T\n\035stubImplementati" +
+      "onCodeRequest\030  \001(\0132-.gauge.messages.Stu" +
+      "bImplementationCodeRequest\022*\n\010fileDiff\030!" +
+      " \001(\0132\030.gauge.messages.FileDiff\022b\n$implem" +
+      "entationFileGlobPatternRequest\030\" \001(\01324.g" +
+      "auge.messages.ImplementationFileGlobPatt" +
+      "ernRequest\022d\n%implementationFileGlobPatt" +
+      "ernResponse\030# \001(\01325.gauge.messages.Imple" +
+      "mentationFileGlobPatternResponse\022J\n\030suit" +
+      "eExecutionResultItem\030$ \001(\0132(.gauge.messa" +
+      "ges.SuiteExecutionResultItem\022,\n\tkeepAliv" +
+      "e\030% \001(\0132\031.gauge.messages.KeepAlive\"\242\007\n\013M" +
+      "essageType\022\025\n\021ExecutionStarting\020\000\022\031\n\025Spe" +
+      "cExecutionStarting\020\001\022\027\n\023SpecExecutionEnd" +
+      "ing\020\002\022\035\n\031ScenarioExecutionStarting\020\003\022\033\n\027" +
+      "ScenarioExecutionEnding\020\004\022\031\n\025StepExecuti" +
+      "onStarting\020\005\022\027\n\023StepExecutionEnding\020\006\022\017\n" +
+      "\013ExecuteStep\020\007\022\023\n\017ExecutionEnding\020\010\022\027\n\023S" +
+      "tepValidateRequest\020\t\022\030\n\024StepValidateResp" +
+      "onse\020\n\022\033\n\027ExecutionStatusResponse\020\013\022\024\n\020S" +
+      "tepNamesRequest\020\014\022\025\n\021StepNamesResponse\020\r" +
+      "\022\026\n\022KillProcessRequest\020\016\022\030\n\024SuiteExecuti" +
+      "onResult\020\017\022\031\n\025ScenarioDataStoreInit\020\020\022\025\n" +
+      "\021SpecDataStoreInit\020\021\022\026\n\022SuiteDataStoreIn" +
+      "it\020\022\022\023\n\017StepNameRequest\020\023\022\024\n\020StepNameRes" +
+      "ponse\020\024\022\023\n\017RefactorRequest\020\025\022\024\n\020Refactor" +
+      "Response\020\026\022\036\n\032UnsupportedMessageResponse" +
+      "\020\027\022\024\n\020CacheFileRequest\020\030\022\030\n\024StepPosition" +
+      "sRequest\020\031\022\031\n\025StepPositionsResponse\020\032\022!\n" +
+      "\035ImplementationFileListRequest\020\033\022\"\n\036Impl" +
+      "ementationFileListResponse\020\034\022!\n\035StubImpl" +
+      "ementationCodeRequest\020\035\022\014\n\010FileDiff\020\036\022(\n" +
+      "$ImplementationFileGlobPatternRequest\020\037\022" +
+      ")\n%ImplementationFileGlobPatternResponse" +
+      "\020 \022\034\n\030SuiteExecutionResultItem\020!\022\r\n\tKeep" +
+      "Alive\020\"B!\n\016gauge.messages\252\002\016Gauge.Messag" +
+      "esb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -42130,183 +48571,195 @@ public final class Messages {
     internal_static_gauge_messages_ExecutionStartingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ExecutionStartingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "SuiteResult", });
     internal_static_gauge_messages_ExecutionEndingRequest_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_gauge_messages_ExecutionEndingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ExecutionEndingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "SuiteResult", });
     internal_static_gauge_messages_SpecExecutionStartingRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_gauge_messages_SpecExecutionStartingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_SpecExecutionStartingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "SpecResult", });
     internal_static_gauge_messages_SpecExecutionEndingRequest_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_gauge_messages_SpecExecutionEndingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_SpecExecutionEndingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "SpecResult", });
     internal_static_gauge_messages_ScenarioExecutionStartingRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_gauge_messages_ScenarioExecutionStartingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ScenarioExecutionStartingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "ScenarioResult", });
     internal_static_gauge_messages_ScenarioExecutionEndingRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_gauge_messages_ScenarioExecutionEndingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ScenarioExecutionEndingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "ScenarioResult", });
     internal_static_gauge_messages_StepExecutionStartingRequest_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_gauge_messages_StepExecutionStartingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepExecutionStartingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
+        new java.lang.String[] { "CurrentExecutionInfo", "StepResult", });
     internal_static_gauge_messages_StepExecutionEndingRequest_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_gauge_messages_StepExecutionEndingRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepExecutionEndingRequest_descriptor,
-        new java.lang.String[] { "CurrentExecutionInfo", });
-    internal_static_gauge_messages_ExecutionInfo_descriptor =
+        new java.lang.String[] { "CurrentExecutionInfo", "StepResult", });
+    internal_static_gauge_messages_ExecutionArg_descriptor =
       getDescriptor().getMessageTypes().get(10);
+    internal_static_gauge_messages_ExecutionArg_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_gauge_messages_ExecutionArg_descriptor,
+        new java.lang.String[] { "FlagName", "FlagValue", });
+    internal_static_gauge_messages_ExecutionInfo_descriptor =
+      getDescriptor().getMessageTypes().get(11);
     internal_static_gauge_messages_ExecutionInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ExecutionInfo_descriptor,
-        new java.lang.String[] { "CurrentSpec", "CurrentScenario", "CurrentStep", "Stacktrace", });
+        new java.lang.String[] { "CurrentSpec", "CurrentScenario", "CurrentStep", "Stacktrace", "ProjectName", "ExecutionArgs", "NumberOfExecutionStreams", "RunnerId", });
     internal_static_gauge_messages_SpecInfo_descriptor =
-      getDescriptor().getMessageTypes().get(11);
+      getDescriptor().getMessageTypes().get(12);
     internal_static_gauge_messages_SpecInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_SpecInfo_descriptor,
         new java.lang.String[] { "Name", "FileName", "IsFailed", "Tags", });
     internal_static_gauge_messages_ScenarioInfo_descriptor =
-      getDescriptor().getMessageTypes().get(12);
+      getDescriptor().getMessageTypes().get(13);
     internal_static_gauge_messages_ScenarioInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ScenarioInfo_descriptor,
         new java.lang.String[] { "Name", "IsFailed", "Tags", });
     internal_static_gauge_messages_StepInfo_descriptor =
-      getDescriptor().getMessageTypes().get(13);
+      getDescriptor().getMessageTypes().get(14);
     internal_static_gauge_messages_StepInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepInfo_descriptor,
         new java.lang.String[] { "Step", "IsFailed", "StackTrace", "ErrorMessage", });
     internal_static_gauge_messages_ExecuteStepRequest_descriptor =
-      getDescriptor().getMessageTypes().get(14);
+      getDescriptor().getMessageTypes().get(15);
     internal_static_gauge_messages_ExecuteStepRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ExecuteStepRequest_descriptor,
         new java.lang.String[] { "ActualStepText", "ParsedStepText", "ScenarioFailing", "Parameters", });
     internal_static_gauge_messages_StepValidateRequest_descriptor =
-      getDescriptor().getMessageTypes().get(15);
+      getDescriptor().getMessageTypes().get(16);
     internal_static_gauge_messages_StepValidateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepValidateRequest_descriptor,
         new java.lang.String[] { "StepText", "NumberOfParameters", "StepValue", });
     internal_static_gauge_messages_StepValidateResponse_descriptor =
-      getDescriptor().getMessageTypes().get(16);
+      getDescriptor().getMessageTypes().get(17);
     internal_static_gauge_messages_StepValidateResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepValidateResponse_descriptor,
         new java.lang.String[] { "IsValid", "ErrorMessage", "ErrorType", "Suggestion", });
     internal_static_gauge_messages_SuiteExecutionResult_descriptor =
-      getDescriptor().getMessageTypes().get(17);
+      getDescriptor().getMessageTypes().get(18);
     internal_static_gauge_messages_SuiteExecutionResult_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_SuiteExecutionResult_descriptor,
         new java.lang.String[] { "SuiteResult", });
+    internal_static_gauge_messages_SuiteExecutionResultItem_descriptor =
+      getDescriptor().getMessageTypes().get(19);
+    internal_static_gauge_messages_SuiteExecutionResultItem_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_gauge_messages_SuiteExecutionResultItem_descriptor,
+        new java.lang.String[] { "ResultItem", });
     internal_static_gauge_messages_StepNamesRequest_descriptor =
-      getDescriptor().getMessageTypes().get(18);
+      getDescriptor().getMessageTypes().get(20);
     internal_static_gauge_messages_StepNamesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepNamesRequest_descriptor,
         new java.lang.String[] { });
     internal_static_gauge_messages_StepNamesResponse_descriptor =
-      getDescriptor().getMessageTypes().get(19);
+      getDescriptor().getMessageTypes().get(21);
     internal_static_gauge_messages_StepNamesResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepNamesResponse_descriptor,
         new java.lang.String[] { "Steps", });
     internal_static_gauge_messages_ScenarioDataStoreInitRequest_descriptor =
-      getDescriptor().getMessageTypes().get(20);
+      getDescriptor().getMessageTypes().get(22);
     internal_static_gauge_messages_ScenarioDataStoreInitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ScenarioDataStoreInitRequest_descriptor,
         new java.lang.String[] { });
     internal_static_gauge_messages_SpecDataStoreInitRequest_descriptor =
-      getDescriptor().getMessageTypes().get(21);
+      getDescriptor().getMessageTypes().get(23);
     internal_static_gauge_messages_SpecDataStoreInitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_SpecDataStoreInitRequest_descriptor,
         new java.lang.String[] { });
     internal_static_gauge_messages_SuiteDataStoreInitRequest_descriptor =
-      getDescriptor().getMessageTypes().get(22);
+      getDescriptor().getMessageTypes().get(24);
     internal_static_gauge_messages_SuiteDataStoreInitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_SuiteDataStoreInitRequest_descriptor,
         new java.lang.String[] { });
     internal_static_gauge_messages_ParameterPosition_descriptor =
-      getDescriptor().getMessageTypes().get(23);
+      getDescriptor().getMessageTypes().get(25);
     internal_static_gauge_messages_ParameterPosition_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ParameterPosition_descriptor,
         new java.lang.String[] { "OldPosition", "NewPosition", });
     internal_static_gauge_messages_RefactorRequest_descriptor =
-      getDescriptor().getMessageTypes().get(24);
+      getDescriptor().getMessageTypes().get(26);
     internal_static_gauge_messages_RefactorRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_RefactorRequest_descriptor,
         new java.lang.String[] { "OldStepValue", "NewStepValue", "ParamPositions", "SaveChanges", });
     internal_static_gauge_messages_FileChanges_descriptor =
-      getDescriptor().getMessageTypes().get(25);
+      getDescriptor().getMessageTypes().get(27);
     internal_static_gauge_messages_FileChanges_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_FileChanges_descriptor,
         new java.lang.String[] { "FileName", "FileContent", "Diffs", });
     internal_static_gauge_messages_RefactorResponse_descriptor =
-      getDescriptor().getMessageTypes().get(26);
+      getDescriptor().getMessageTypes().get(28);
     internal_static_gauge_messages_RefactorResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_RefactorResponse_descriptor,
         new java.lang.String[] { "Success", "Error", "FilesChanged", "FileChanges", });
     internal_static_gauge_messages_StepNameRequest_descriptor =
-      getDescriptor().getMessageTypes().get(27);
+      getDescriptor().getMessageTypes().get(29);
     internal_static_gauge_messages_StepNameRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepNameRequest_descriptor,
         new java.lang.String[] { "StepValue", });
     internal_static_gauge_messages_StepNameResponse_descriptor =
-      getDescriptor().getMessageTypes().get(28);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_gauge_messages_StepNameResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepNameResponse_descriptor,
         new java.lang.String[] { "IsStepPresent", "StepName", "HasAlias", "FileName", "Span", });
     internal_static_gauge_messages_UnsupportedMessageResponse_descriptor =
-      getDescriptor().getMessageTypes().get(29);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_gauge_messages_UnsupportedMessageResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_UnsupportedMessageResponse_descriptor,
         new java.lang.String[] { "Message", });
     internal_static_gauge_messages_CacheFileRequest_descriptor =
-      getDescriptor().getMessageTypes().get(30);
+      getDescriptor().getMessageTypes().get(32);
     internal_static_gauge_messages_CacheFileRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_CacheFileRequest_descriptor,
         new java.lang.String[] { "Content", "FilePath", "IsClosed", "Status", });
     internal_static_gauge_messages_StepPositionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(31);
+      getDescriptor().getMessageTypes().get(33);
     internal_static_gauge_messages_StepPositionsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepPositionsRequest_descriptor,
         new java.lang.String[] { "FilePath", });
     internal_static_gauge_messages_StepPositionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(32);
+      getDescriptor().getMessageTypes().get(34);
     internal_static_gauge_messages_StepPositionsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StepPositionsResponse_descriptor,
@@ -42318,53 +48771,65 @@ public final class Messages {
         internal_static_gauge_messages_StepPositionsResponse_StepPosition_descriptor,
         new java.lang.String[] { "StepValue", "Span", });
     internal_static_gauge_messages_ImplementationFileGlobPatternRequest_descriptor =
-      getDescriptor().getMessageTypes().get(33);
+      getDescriptor().getMessageTypes().get(35);
     internal_static_gauge_messages_ImplementationFileGlobPatternRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ImplementationFileGlobPatternRequest_descriptor,
         new java.lang.String[] { });
     internal_static_gauge_messages_ImplementationFileGlobPatternResponse_descriptor =
-      getDescriptor().getMessageTypes().get(34);
+      getDescriptor().getMessageTypes().get(36);
     internal_static_gauge_messages_ImplementationFileGlobPatternResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ImplementationFileGlobPatternResponse_descriptor,
         new java.lang.String[] { "GlobPatterns", });
     internal_static_gauge_messages_ImplementationFileListRequest_descriptor =
-      getDescriptor().getMessageTypes().get(35);
+      getDescriptor().getMessageTypes().get(37);
     internal_static_gauge_messages_ImplementationFileListRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ImplementationFileListRequest_descriptor,
         new java.lang.String[] { });
     internal_static_gauge_messages_ImplementationFileListResponse_descriptor =
-      getDescriptor().getMessageTypes().get(36);
+      getDescriptor().getMessageTypes().get(38);
     internal_static_gauge_messages_ImplementationFileListResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ImplementationFileListResponse_descriptor,
         new java.lang.String[] { "ImplementationFilePaths", });
     internal_static_gauge_messages_StubImplementationCodeRequest_descriptor =
-      getDescriptor().getMessageTypes().get(37);
+      getDescriptor().getMessageTypes().get(39);
     internal_static_gauge_messages_StubImplementationCodeRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_StubImplementationCodeRequest_descriptor,
         new java.lang.String[] { "ImplementationFilePath", "Codes", });
     internal_static_gauge_messages_TextDiff_descriptor =
-      getDescriptor().getMessageTypes().get(38);
+      getDescriptor().getMessageTypes().get(40);
     internal_static_gauge_messages_TextDiff_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_TextDiff_descriptor,
         new java.lang.String[] { "Span", "Content", });
     internal_static_gauge_messages_FileDiff_descriptor =
-      getDescriptor().getMessageTypes().get(39);
+      getDescriptor().getMessageTypes().get(41);
     internal_static_gauge_messages_FileDiff_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_FileDiff_descriptor,
         new java.lang.String[] { "FilePath", "TextDiffs", });
+    internal_static_gauge_messages_KeepAlive_descriptor =
+      getDescriptor().getMessageTypes().get(42);
+    internal_static_gauge_messages_KeepAlive_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_gauge_messages_KeepAlive_descriptor,
+        new java.lang.String[] { "PluginId", });
+    internal_static_gauge_messages_Empty_descriptor =
+      getDescriptor().getMessageTypes().get(43);
+    internal_static_gauge_messages_Empty_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_gauge_messages_Empty_descriptor,
+        new java.lang.String[] { });
     internal_static_gauge_messages_Message_descriptor =
-      getDescriptor().getMessageTypes().get(40);
+      getDescriptor().getMessageTypes().get(44);
     internal_static_gauge_messages_Message_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_Message_descriptor,
-        new java.lang.String[] { "MessageType", "MessageId", "ExecutionStartingRequest", "SpecExecutionStartingRequest", "SpecExecutionEndingRequest", "ScenarioExecutionStartingRequest", "ScenarioExecutionEndingRequest", "StepExecutionStartingRequest", "StepExecutionEndingRequest", "ExecuteStepRequest", "ExecutionEndingRequest", "StepValidateRequest", "StepValidateResponse", "ExecutionStatusResponse", "StepNamesRequest", "StepNamesResponse", "SuiteExecutionResult", "KillProcessRequest", "ScenarioDataStoreInitRequest", "SpecDataStoreInitRequest", "SuiteDataStoreInitRequest", "StepNameRequest", "StepNameResponse", "RefactorRequest", "RefactorResponse", "UnsupportedMessageResponse", "CacheFileRequest", "StepPositionsRequest", "StepPositionsResponse", "ImplementationFileListRequest", "ImplementationFileListResponse", "StubImplementationCodeRequest", "FileDiff", "ImplementationFileGlobPatternRequest", "ImplementationFileGlobPatternResponse", });
+        new java.lang.String[] { "MessageType", "MessageId", "ExecutionStartingRequest", "SpecExecutionStartingRequest", "SpecExecutionEndingRequest", "ScenarioExecutionStartingRequest", "ScenarioExecutionEndingRequest", "StepExecutionStartingRequest", "StepExecutionEndingRequest", "ExecuteStepRequest", "ExecutionEndingRequest", "StepValidateRequest", "StepValidateResponse", "ExecutionStatusResponse", "StepNamesRequest", "StepNamesResponse", "SuiteExecutionResult", "KillProcessRequest", "ScenarioDataStoreInitRequest", "SpecDataStoreInitRequest", "SuiteDataStoreInitRequest", "StepNameRequest", "StepNameResponse", "RefactorRequest", "RefactorResponse", "UnsupportedMessageResponse", "CacheFileRequest", "StepPositionsRequest", "StepPositionsResponse", "ImplementationFileListRequest", "ImplementationFileListResponse", "StubImplementationCodeRequest", "FileDiff", "ImplementationFileGlobPatternRequest", "ImplementationFileGlobPatternResponse", "SuiteExecutionResultItem", "KeepAlive", });
     gauge.messages.Spec.getDescriptor();
   }
 

--- a/src/main/java/gauge/messages/Spec.java
+++ b/src/main/java/gauge/messages/Spec.java
@@ -492,53 +492,133 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 12;</code>
+     * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 12;</code>
+     * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
      */
-    int getPreHookScreenshotsCount();
+    @java.lang.Deprecated int getPreHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 12;</code>
+     * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPreHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPreHookScreenshots(int index);
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 13;</code>
+     * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 13;</code>
+     * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
      */
-    int getPostHookScreenshotsCount();
+    @java.lang.Deprecated int getPostHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 13;</code>
+     * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPostHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPostHookScreenshots(int index);
+
+    /**
+     * <pre>
+     *&#47; meta field to indicate the number of items in the list
+     * / used when items are sent as individual chunk
+     * </pre>
+     *
+     * <code>int64 itemCount = 14;</code>
+     */
+    long getItemCount();
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    java.util.List<java.lang.String>
+        getPreHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    int getPreHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    java.lang.String getPreHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index);
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    java.util.List<java.lang.String>
+        getPostHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    int getPostHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    java.lang.String getPostHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index);
   }
   /**
    * <pre>
@@ -571,6 +651,9 @@ public final class Spec {
       postHookMessage_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       preHookScreenshots_ = java.util.Collections.emptyList();
       postHookScreenshots_ = java.util.Collections.emptyList();
+      itemCount_ = 0L;
+      preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -702,6 +785,29 @@ public final class Spec {
               postHookScreenshots_.add(input.readBytes());
               break;
             }
+            case 112: {
+
+              itemCount_ = input.readInt64();
+              break;
+            }
+            case 122: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
+                preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00004000;
+              }
+              preHookScreenshotFiles_.add(s);
+              break;
+            }
+            case 130: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00008000) == 0x00008000)) {
+                postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00008000;
+              }
+              postHookScreenshotFiles_.add(s);
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -746,6 +852,12 @@ public final class Spec {
         }
         if (((mutable_bitField0_ & 0x00001000) == 0x00001000)) {
           postHookScreenshots_ = java.util.Collections.unmodifiableList(postHookScreenshots_);
+        }
+        if (((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00008000) == 0x00008000)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1256,33 +1368,33 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> preHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 12;</code>
+     * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPreHookScreenshotsList() {
       return preHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 12;</code>
+     * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
      */
-    public int getPreHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPreHookScreenshotsCount() {
       return preHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 12;</code>
+     * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
       return preHookScreenshots_.get(index);
     }
 
@@ -1290,34 +1402,138 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> postHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 13;</code>
+     * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPostHookScreenshotsList() {
       return postHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 13;</code>
+     * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
      */
-    public int getPostHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPostHookScreenshotsCount() {
       return postHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 13;</code>
+     * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
       return postHookScreenshots_.get(index);
+    }
+
+    public static final int ITEMCOUNT_FIELD_NUMBER = 14;
+    private long itemCount_;
+    /**
+     * <pre>
+     *&#47; meta field to indicate the number of items in the list
+     * / used when items are sent as individual chunk
+     * </pre>
+     *
+     * <code>int64 itemCount = 14;</code>
+     */
+    public long getItemCount() {
+      return itemCount_;
+    }
+
+    public static final int PREHOOKSCREENSHOTFILES_FIELD_NUMBER = 15;
+    private com.google.protobuf.LazyStringList preHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPreHookScreenshotFilesList() {
+      return preHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    public int getPreHookScreenshotFilesCount() {
+      return preHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    public java.lang.String getPreHookScreenshotFiles(int index) {
+      return preHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 15;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index) {
+      return preHookScreenshotFiles_.getByteString(index);
+    }
+
+    public static final int POSTHOOKSCREENSHOTFILES_FIELD_NUMBER = 16;
+    private com.google.protobuf.LazyStringList postHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPostHookScreenshotFilesList() {
+      return postHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    public int getPostHookScreenshotFilesCount() {
+      return postHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    public java.lang.String getPostHookScreenshotFiles(int index) {
+      return postHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 16;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index) {
+      return postHookScreenshotFiles_.getByteString(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1372,6 +1588,15 @@ public final class Spec {
       }
       for (int i = 0; i < postHookScreenshots_.size(); i++) {
         output.writeBytes(13, postHookScreenshots_.get(i));
+      }
+      if (itemCount_ != 0L) {
+        output.writeInt64(14, itemCount_);
+      }
+      for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 15, preHookScreenshotFiles_.getRaw(i));
+      }
+      for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 16, postHookScreenshotFiles_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -1462,6 +1687,26 @@ public final class Spec {
         size += dataSize;
         size += 1 * getPostHookScreenshotsList().size();
       }
+      if (itemCount_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(14, itemCount_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(preHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getPreHookScreenshotFilesList().size();
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(postHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getPostHookScreenshotFilesList().size();
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -1504,6 +1749,12 @@ public final class Spec {
           .equals(other.getPreHookScreenshotsList());
       result = result && getPostHookScreenshotsList()
           .equals(other.getPostHookScreenshotsList());
+      result = result && (getItemCount()
+          == other.getItemCount());
+      result = result && getPreHookScreenshotFilesList()
+          .equals(other.getPreHookScreenshotFilesList());
+      result = result && getPostHookScreenshotFilesList()
+          .equals(other.getPostHookScreenshotFilesList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -1561,6 +1812,17 @@ public final class Spec {
       if (getPostHookScreenshotsCount() > 0) {
         hash = (37 * hash) + POSTHOOKSCREENSHOTS_FIELD_NUMBER;
         hash = (53 * hash) + getPostHookScreenshotsList().hashCode();
+      }
+      hash = (37 * hash) + ITEMCOUNT_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getItemCount());
+      if (getPreHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + PREHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPreHookScreenshotFilesList().hashCode();
+      }
+      if (getPostHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + POSTHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPostHookScreenshotFilesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -1741,6 +2003,12 @@ public final class Spec {
         bitField0_ = (bitField0_ & ~0x00000800);
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00001000);
+        itemCount_ = 0L;
+
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00004000);
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00008000);
         return this;
       }
 
@@ -1834,6 +2102,17 @@ public final class Spec {
           bitField0_ = (bitField0_ & ~0x00001000);
         }
         result.postHookScreenshots_ = postHookScreenshots_;
+        result.itemCount_ = itemCount_;
+        if (((bitField0_ & 0x00004000) == 0x00004000)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00004000);
+        }
+        result.preHookScreenshotFiles_ = preHookScreenshotFiles_;
+        if (((bitField0_ & 0x00008000) == 0x00008000)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00008000);
+        }
+        result.postHookScreenshotFiles_ = postHookScreenshotFiles_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2039,6 +2318,29 @@ public final class Spec {
           } else {
             ensurePostHookScreenshotsIsMutable();
             postHookScreenshots_.addAll(other.postHookScreenshots_);
+          }
+          onChanged();
+        }
+        if (other.getItemCount() != 0L) {
+          setItemCount(other.getItemCount());
+        }
+        if (!other.preHookScreenshotFiles_.isEmpty()) {
+          if (preHookScreenshotFiles_.isEmpty()) {
+            preHookScreenshotFiles_ = other.preHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00004000);
+          } else {
+            ensurePreHookScreenshotFilesIsMutable();
+            preHookScreenshotFiles_.addAll(other.preHookScreenshotFiles_);
+          }
+          onChanged();
+        }
+        if (!other.postHookScreenshotFiles_.isEmpty()) {
+          if (postHookScreenshotFiles_.isEmpty()) {
+            postHookScreenshotFiles_ = other.postHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00008000);
+          } else {
+            ensurePostHookScreenshotFilesIsMutable();
+            postHookScreenshotFiles_.addAll(other.postHookScreenshotFiles_);
           }
           onChanged();
         }
@@ -3883,43 +4185,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPreHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(preHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public int getPreHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPreHookScreenshotsCount() {
         return preHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
         return preHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public Builder setPreHookScreenshots(
+      @java.lang.Deprecated public Builder setPreHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -3931,12 +4233,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3947,12 +4249,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public Builder addAllPreHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPreHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePreHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -3962,12 +4264,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 12;</code>
+       * <code>repeated bytes preHookScreenshots = 12 [deprecated = true];</code>
        */
-      public Builder clearPreHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPreHookScreenshots() {
         preHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000800);
         onChanged();
@@ -3983,43 +4285,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPostHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(postHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public int getPostHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPostHookScreenshotsCount() {
         return postHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
         return postHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public Builder setPostHookScreenshots(
+      @java.lang.Deprecated public Builder setPostHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -4031,12 +4333,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -4047,12 +4349,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public Builder addAllPostHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPostHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePostHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -4062,14 +4364,315 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 13;</code>
+       * <code>repeated bytes postHookScreenshots = 13 [deprecated = true];</code>
        */
-      public Builder clearPostHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPostHookScreenshots() {
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00001000);
+        onChanged();
+        return this;
+      }
+
+      private long itemCount_ ;
+      /**
+       * <pre>
+       *&#47; meta field to indicate the number of items in the list
+       * / used when items are sent as individual chunk
+       * </pre>
+       *
+       * <code>int64 itemCount = 14;</code>
+       */
+      public long getItemCount() {
+        return itemCount_;
+      }
+      /**
+       * <pre>
+       *&#47; meta field to indicate the number of items in the list
+       * / used when items are sent as individual chunk
+       * </pre>
+       *
+       * <code>int64 itemCount = 14;</code>
+       */
+      public Builder setItemCount(long value) {
+        
+        itemCount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; meta field to indicate the number of items in the list
+       * / used when items are sent as individual chunk
+       * </pre>
+       *
+       * <code>int64 itemCount = 14;</code>
+       */
+      public Builder clearItemCount() {
+        
+        itemCount_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePreHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00004000) == 0x00004000)) {
+          preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(preHookScreenshotFiles_);
+          bitField0_ |= 0x00004000;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPreHookScreenshotFilesList() {
+        return preHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public int getPreHookScreenshotFilesCount() {
+        return preHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public java.lang.String getPreHookScreenshotFiles(int index) {
+        return preHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPreHookScreenshotFilesBytes(int index) {
+        return preHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public Builder setPreHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public Builder addPreHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public Builder addAllPreHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePreHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, preHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public Builder clearPreHookScreenshotFiles() {
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00004000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 15;</code>
+       */
+      public Builder addPreHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePostHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00008000) == 0x00008000)) {
+          postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(postHookScreenshotFiles_);
+          bitField0_ |= 0x00008000;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPostHookScreenshotFilesList() {
+        return postHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public int getPostHookScreenshotFilesCount() {
+        return postHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public java.lang.String getPostHookScreenshotFiles(int index) {
+        return postHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPostHookScreenshotFilesBytes(int index) {
+        return postHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public Builder setPostHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public Builder addPostHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public Builder addAllPostHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePostHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, postHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public Builder clearPostHookScreenshotFiles() {
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00008000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 16;</code>
+       */
+      public Builder addPostHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
         onChanged();
         return this;
       }
@@ -4321,6 +4924,24 @@ public final class Spec {
      * <code>.gauge.messages.ProtoTags tags = 8;</code>
      */
     gauge.messages.Spec.ProtoTagsOrBuilder getTagsOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the Filename that the item belongs to
+     * </pre>
+     *
+     * <code>string fileName = 9;</code>
+     */
+    java.lang.String getFileName();
+    /**
+     * <pre>
+     *&#47; Holds the Filename that the item belongs to
+     * </pre>
+     *
+     * <code>string fileName = 9;</code>
+     */
+    com.google.protobuf.ByteString
+        getFileNameBytes();
   }
   /**
    * <pre>
@@ -4340,6 +4961,7 @@ public final class Spec {
     }
     private ProtoItem() {
       itemType_ = 0;
+      fileName_ = "";
     }
 
     @java.lang.Override
@@ -4461,6 +5083,12 @@ public final class Spec {
                 tags_ = subBuilder.buildPartial();
               }
 
+              break;
+            }
+            case 74: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              fileName_ = s;
               break;
             }
             default: {
@@ -4954,6 +5582,48 @@ public final class Spec {
       return getTags();
     }
 
+    public static final int FILENAME_FIELD_NUMBER = 9;
+    private volatile java.lang.Object fileName_;
+    /**
+     * <pre>
+     *&#47; Holds the Filename that the item belongs to
+     * </pre>
+     *
+     * <code>string fileName = 9;</code>
+     */
+    public java.lang.String getFileName() {
+      java.lang.Object ref = fileName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        fileName_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Holds the Filename that the item belongs to
+     * </pre>
+     *
+     * <code>string fileName = 9;</code>
+     */
+    public com.google.protobuf.ByteString
+        getFileNameBytes() {
+      java.lang.Object ref = fileName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        fileName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -4991,6 +5661,9 @@ public final class Spec {
       }
       if (tags_ != null) {
         output.writeMessage(8, getTags());
+      }
+      if (!getFileNameBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 9, fileName_);
       }
       unknownFields.writeTo(output);
     }
@@ -5032,6 +5705,9 @@ public final class Spec {
       if (tags_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(8, getTags());
+      }
+      if (!getFileNameBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(9, fileName_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5085,6 +5761,8 @@ public final class Spec {
         result = result && getTags()
             .equals(other.getTags());
       }
+      result = result && getFileName()
+          .equals(other.getFileName());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -5126,6 +5804,8 @@ public final class Spec {
         hash = (37 * hash) + TAGS_FIELD_NUMBER;
         hash = (53 * hash) + getTags().hashCode();
       }
+      hash = (37 * hash) + FILENAME_FIELD_NUMBER;
+      hash = (53 * hash) + getFileName().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -5307,6 +5987,8 @@ public final class Spec {
           tags_ = null;
           tagsBuilder_ = null;
         }
+        fileName_ = "";
+
         return this;
       }
 
@@ -5369,6 +6051,7 @@ public final class Spec {
         } else {
           result.tags_ = tagsBuilder_.build();
         }
+        result.fileName_ = fileName_;
         onBuilt();
         return result;
       }
@@ -5440,6 +6123,10 @@ public final class Spec {
         }
         if (other.hasTags()) {
           mergeTags(other.getTags());
+        }
+        if (!other.getFileName().isEmpty()) {
+          fileName_ = other.fileName_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -6605,6 +7292,95 @@ public final class Spec {
         }
         return tagsBuilder_;
       }
+
+      private java.lang.Object fileName_ = "";
+      /**
+       * <pre>
+       *&#47; Holds the Filename that the item belongs to
+       * </pre>
+       *
+       * <code>string fileName = 9;</code>
+       */
+      public java.lang.String getFileName() {
+        java.lang.Object ref = fileName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          fileName_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the Filename that the item belongs to
+       * </pre>
+       *
+       * <code>string fileName = 9;</code>
+       */
+      public com.google.protobuf.ByteString
+          getFileNameBytes() {
+        java.lang.Object ref = fileName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          fileName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the Filename that the item belongs to
+       * </pre>
+       *
+       * <code>string fileName = 9;</code>
+       */
+      public Builder setFileName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        fileName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the Filename that the item belongs to
+       * </pre>
+       *
+       * <code>string fileName = 9;</code>
+       */
+      public Builder clearFileName() {
+        
+        fileName_ = getDefaultInstance().getFileName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the Filename that the item belongs to
+       * </pre>
+       *
+       * <code>string fileName = 9;</code>
+       */
+      public Builder setFileNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        fileName_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -7161,53 +7937,123 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 19;</code>
+     * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 19;</code>
+     * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
      */
-    int getPreHookScreenshotsCount();
+    @java.lang.Deprecated int getPreHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 19;</code>
+     * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPreHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPreHookScreenshots(int index);
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 20;</code>
+     * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 20;</code>
+     * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
      */
-    int getPostHookScreenshotsCount();
+    @java.lang.Deprecated int getPostHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 20;</code>
+     * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPostHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPostHookScreenshots(int index);
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    java.util.List<java.lang.String>
+        getPreHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    int getPreHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    java.lang.String getPreHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index);
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    java.util.List<java.lang.String>
+        getPostHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    int getPostHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    java.lang.String getPostHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index);
   }
   /**
    * <pre>
@@ -7243,6 +8089,8 @@ public final class Spec {
       postHookMessage_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       preHookScreenshots_ = java.util.Collections.emptyList();
       postHookScreenshots_ = java.util.Collections.emptyList();
+      preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -7438,6 +8286,24 @@ public final class Spec {
               postHookScreenshots_.add(input.readBytes());
               break;
             }
+            case 170: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00100000) == 0x00100000)) {
+                preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00100000;
+              }
+              preHookScreenshotFiles_.add(s);
+              break;
+            }
+            case 178: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00200000) == 0x00200000)) {
+                postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00200000;
+              }
+              postHookScreenshotFiles_.add(s);
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -7485,6 +8351,12 @@ public final class Spec {
         }
         if (((mutable_bitField0_ & 0x00080000) == 0x00080000)) {
           postHookScreenshots_ = java.util.Collections.unmodifiableList(postHookScreenshots_);
+        }
+        if (((mutable_bitField0_ & 0x00100000) == 0x00100000)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00200000) == 0x00200000)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -8190,33 +9062,33 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> preHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 19;</code>
+     * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPreHookScreenshotsList() {
       return preHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 19;</code>
+     * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
      */
-    public int getPreHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPreHookScreenshotsCount() {
       return preHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 19;</code>
+     * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
       return preHookScreenshots_.get(index);
     }
 
@@ -8224,34 +9096,124 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> postHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 20;</code>
+     * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPostHookScreenshotsList() {
       return postHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 20;</code>
+     * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
      */
-    public int getPostHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPostHookScreenshotsCount() {
       return postHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 20;</code>
+     * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
       return postHookScreenshots_.get(index);
+    }
+
+    public static final int PREHOOKSCREENSHOTFILES_FIELD_NUMBER = 21;
+    private com.google.protobuf.LazyStringList preHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPreHookScreenshotFilesList() {
+      return preHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public int getPreHookScreenshotFilesCount() {
+      return preHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public java.lang.String getPreHookScreenshotFiles(int index) {
+      return preHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index) {
+      return preHookScreenshotFiles_.getByteString(index);
+    }
+
+    public static final int POSTHOOKSCREENSHOTFILES_FIELD_NUMBER = 22;
+    private com.google.protobuf.LazyStringList postHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPostHookScreenshotFilesList() {
+      return postHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public int getPostHookScreenshotFilesCount() {
+      return postHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public java.lang.String getPostHookScreenshotFiles(int index) {
+      return postHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index) {
+      return postHookScreenshotFiles_.getByteString(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -8327,6 +9289,12 @@ public final class Spec {
       }
       for (int i = 0; i < postHookScreenshots_.size(); i++) {
         output.writeBytes(20, postHookScreenshots_.get(i));
+      }
+      for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 21, preHookScreenshotFiles_.getRaw(i));
+      }
+      for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 22, postHookScreenshotFiles_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -8449,6 +9417,22 @@ public final class Spec {
         size += dataSize;
         size += 2 * getPostHookScreenshotsList().size();
       }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(preHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getPreHookScreenshotFilesList().size();
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(postHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getPostHookScreenshotFilesList().size();
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -8513,6 +9497,10 @@ public final class Spec {
           .equals(other.getPreHookScreenshotsList());
       result = result && getPostHookScreenshotsList()
           .equals(other.getPostHookScreenshotsList());
+      result = result && getPreHookScreenshotFilesList()
+          .equals(other.getPreHookScreenshotFilesList());
+      result = result && getPostHookScreenshotFilesList()
+          .equals(other.getPostHookScreenshotFilesList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -8594,6 +9582,14 @@ public final class Spec {
       if (getPostHookScreenshotsCount() > 0) {
         hash = (37 * hash) + POSTHOOKSCREENSHOTS_FIELD_NUMBER;
         hash = (53 * hash) + getPostHookScreenshotsList().hashCode();
+      }
+      if (getPreHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + PREHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPreHookScreenshotFilesList().hashCode();
+      }
+      if (getPostHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + POSTHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPostHookScreenshotFilesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -8799,6 +9795,10 @@ public final class Spec {
         bitField0_ = (bitField0_ & ~0x00040000);
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00080000);
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00100000);
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
 
@@ -8915,6 +9915,16 @@ public final class Spec {
           bitField0_ = (bitField0_ & ~0x00080000);
         }
         result.postHookScreenshots_ = postHookScreenshots_;
+        if (((bitField0_ & 0x00100000) == 0x00100000)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00100000);
+        }
+        result.preHookScreenshotFiles_ = preHookScreenshotFiles_;
+        if (((bitField0_ & 0x00200000) == 0x00200000)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00200000);
+        }
+        result.postHookScreenshotFiles_ = postHookScreenshotFiles_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -9148,6 +10158,26 @@ public final class Spec {
           } else {
             ensurePostHookScreenshotsIsMutable();
             postHookScreenshots_.addAll(other.postHookScreenshots_);
+          }
+          onChanged();
+        }
+        if (!other.preHookScreenshotFiles_.isEmpty()) {
+          if (preHookScreenshotFiles_.isEmpty()) {
+            preHookScreenshotFiles_ = other.preHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00100000);
+          } else {
+            ensurePreHookScreenshotFilesIsMutable();
+            preHookScreenshotFiles_.addAll(other.preHookScreenshotFiles_);
+          }
+          onChanged();
+        }
+        if (!other.postHookScreenshotFiles_.isEmpty()) {
+          if (postHookScreenshotFiles_.isEmpty()) {
+            postHookScreenshotFiles_ = other.postHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00200000);
+          } else {
+            ensurePostHookScreenshotFilesIsMutable();
+            postHookScreenshotFiles_.addAll(other.postHookScreenshotFiles_);
           }
           onChanged();
         }
@@ -11722,43 +12752,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPreHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(preHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public int getPreHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPreHookScreenshotsCount() {
         return preHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
         return preHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public Builder setPreHookScreenshots(
+      @java.lang.Deprecated public Builder setPreHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -11770,12 +12800,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -11786,12 +12816,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public Builder addAllPreHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPreHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePreHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -11801,12 +12831,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 19;</code>
+       * <code>repeated bytes preHookScreenshots = 19 [deprecated = true];</code>
        */
-      public Builder clearPreHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPreHookScreenshots() {
         preHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00040000);
         onChanged();
@@ -11822,43 +12852,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPostHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(postHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public int getPostHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPostHookScreenshotsCount() {
         return postHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
         return postHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public Builder setPostHookScreenshots(
+      @java.lang.Deprecated public Builder setPostHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -11870,12 +12900,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -11886,12 +12916,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public Builder addAllPostHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPostHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePostHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -11901,14 +12931,274 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 20;</code>
+       * <code>repeated bytes postHookScreenshots = 20 [deprecated = true];</code>
        */
-      public Builder clearPostHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPostHookScreenshots() {
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00080000);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePreHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00100000) == 0x00100000)) {
+          preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(preHookScreenshotFiles_);
+          bitField0_ |= 0x00100000;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPreHookScreenshotFilesList() {
+        return preHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public int getPreHookScreenshotFilesCount() {
+        return preHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public java.lang.String getPreHookScreenshotFiles(int index) {
+        return preHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPreHookScreenshotFilesBytes(int index) {
+        return preHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder setPreHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder addPreHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder addAllPreHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePreHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, preHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder clearPreHookScreenshotFiles() {
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00100000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder addPreHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePostHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00200000) == 0x00200000)) {
+          postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(postHookScreenshotFiles_);
+          bitField0_ |= 0x00200000;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPostHookScreenshotFilesList() {
+        return postHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public int getPostHookScreenshotFilesCount() {
+        return postHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public java.lang.String getPostHookScreenshotFiles(int index) {
+        return postHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPostHookScreenshotFilesBytes(int index) {
+        return postHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder setPostHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder addPostHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder addAllPostHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePostHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, postHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder clearPostHookScreenshotFiles() {
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00200000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder addPostHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
         onChanged();
         return this;
       }
@@ -12679,6 +13969,83 @@ public final class Spec {
      * <code>int32 tableRowIndex = 2;</code>
      */
     int getTableRowIndex();
+
+    /**
+     * <pre>
+     *&#47; Row Index of scenario data table against which the current scenario is executed
+     * </pre>
+     *
+     * <code>int32 scenarioTableRowIndex = 3;</code>
+     */
+    int getScenarioTableRowIndex();
+
+    /**
+     * <pre>
+     *&#47; Executed against a spec data table
+     * </pre>
+     *
+     * <code>bool isSpecTableDriven = 4;</code>
+     */
+    boolean getIsSpecTableDriven();
+
+    /**
+     * <pre>
+     *&#47; Executed against a scenario data table
+     * </pre>
+     *
+     * <code>bool isScenarioTableDriven = 5;</code>
+     */
+    boolean getIsScenarioTableDriven();
+
+    /**
+     * <pre>
+     *&#47; Holds the scenario data table
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+     */
+    boolean hasScenarioDataTable();
+    /**
+     * <pre>
+     *&#47; Holds the scenario data table
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+     */
+    gauge.messages.Spec.ProtoTable getScenarioDataTable();
+    /**
+     * <pre>
+     *&#47; Holds the scenario data table
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+     */
+    gauge.messages.Spec.ProtoTableOrBuilder getScenarioDataTableOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Hold the row of scenario data table.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+     */
+    boolean hasScenarioTableRow();
+    /**
+     * <pre>
+     *&#47; Hold the row of scenario data table.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+     */
+    gauge.messages.Spec.ProtoTable getScenarioTableRow();
+    /**
+     * <pre>
+     *&#47; Hold the row of scenario data table.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+     */
+    gauge.messages.Spec.ProtoTableOrBuilder getScenarioTableRowOrBuilder();
   }
   /**
    * <pre>
@@ -12698,6 +14065,9 @@ public final class Spec {
     }
     private ProtoTableDrivenScenario() {
       tableRowIndex_ = 0;
+      scenarioTableRowIndex_ = 0;
+      isSpecTableDriven_ = false;
+      isScenarioTableDriven_ = false;
     }
 
     @java.lang.Override
@@ -12740,6 +14110,47 @@ public final class Spec {
             case 16: {
 
               tableRowIndex_ = input.readInt32();
+              break;
+            }
+            case 24: {
+
+              scenarioTableRowIndex_ = input.readInt32();
+              break;
+            }
+            case 32: {
+
+              isSpecTableDriven_ = input.readBool();
+              break;
+            }
+            case 40: {
+
+              isScenarioTableDriven_ = input.readBool();
+              break;
+            }
+            case 50: {
+              gauge.messages.Spec.ProtoTable.Builder subBuilder = null;
+              if (scenarioDataTable_ != null) {
+                subBuilder = scenarioDataTable_.toBuilder();
+              }
+              scenarioDataTable_ = input.readMessage(gauge.messages.Spec.ProtoTable.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(scenarioDataTable_);
+                scenarioDataTable_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 58: {
+              gauge.messages.Spec.ProtoTable.Builder subBuilder = null;
+              if (scenarioTableRow_ != null) {
+                subBuilder = scenarioTableRow_.toBuilder();
+              }
+              scenarioTableRow_ = input.readMessage(gauge.messages.Spec.ProtoTable.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(scenarioTableRow_);
+                scenarioTableRow_ = subBuilder.buildPartial();
+              }
+
               break;
             }
             default: {
@@ -12820,6 +14231,111 @@ public final class Spec {
       return tableRowIndex_;
     }
 
+    public static final int SCENARIOTABLEROWINDEX_FIELD_NUMBER = 3;
+    private int scenarioTableRowIndex_;
+    /**
+     * <pre>
+     *&#47; Row Index of scenario data table against which the current scenario is executed
+     * </pre>
+     *
+     * <code>int32 scenarioTableRowIndex = 3;</code>
+     */
+    public int getScenarioTableRowIndex() {
+      return scenarioTableRowIndex_;
+    }
+
+    public static final int ISSPECTABLEDRIVEN_FIELD_NUMBER = 4;
+    private boolean isSpecTableDriven_;
+    /**
+     * <pre>
+     *&#47; Executed against a spec data table
+     * </pre>
+     *
+     * <code>bool isSpecTableDriven = 4;</code>
+     */
+    public boolean getIsSpecTableDriven() {
+      return isSpecTableDriven_;
+    }
+
+    public static final int ISSCENARIOTABLEDRIVEN_FIELD_NUMBER = 5;
+    private boolean isScenarioTableDriven_;
+    /**
+     * <pre>
+     *&#47; Executed against a scenario data table
+     * </pre>
+     *
+     * <code>bool isScenarioTableDriven = 5;</code>
+     */
+    public boolean getIsScenarioTableDriven() {
+      return isScenarioTableDriven_;
+    }
+
+    public static final int SCENARIODATATABLE_FIELD_NUMBER = 6;
+    private gauge.messages.Spec.ProtoTable scenarioDataTable_;
+    /**
+     * <pre>
+     *&#47; Holds the scenario data table
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+     */
+    public boolean hasScenarioDataTable() {
+      return scenarioDataTable_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the scenario data table
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+     */
+    public gauge.messages.Spec.ProtoTable getScenarioDataTable() {
+      return scenarioDataTable_ == null ? gauge.messages.Spec.ProtoTable.getDefaultInstance() : scenarioDataTable_;
+    }
+    /**
+     * <pre>
+     *&#47; Holds the scenario data table
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+     */
+    public gauge.messages.Spec.ProtoTableOrBuilder getScenarioDataTableOrBuilder() {
+      return getScenarioDataTable();
+    }
+
+    public static final int SCENARIOTABLEROW_FIELD_NUMBER = 7;
+    private gauge.messages.Spec.ProtoTable scenarioTableRow_;
+    /**
+     * <pre>
+     *&#47; Hold the row of scenario data table.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+     */
+    public boolean hasScenarioTableRow() {
+      return scenarioTableRow_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Hold the row of scenario data table.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+     */
+    public gauge.messages.Spec.ProtoTable getScenarioTableRow() {
+      return scenarioTableRow_ == null ? gauge.messages.Spec.ProtoTable.getDefaultInstance() : scenarioTableRow_;
+    }
+    /**
+     * <pre>
+     *&#47; Hold the row of scenario data table.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+     */
+    public gauge.messages.Spec.ProtoTableOrBuilder getScenarioTableRowOrBuilder() {
+      return getScenarioTableRow();
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -12840,6 +14356,21 @@ public final class Spec {
       if (tableRowIndex_ != 0) {
         output.writeInt32(2, tableRowIndex_);
       }
+      if (scenarioTableRowIndex_ != 0) {
+        output.writeInt32(3, scenarioTableRowIndex_);
+      }
+      if (isSpecTableDriven_ != false) {
+        output.writeBool(4, isSpecTableDriven_);
+      }
+      if (isScenarioTableDriven_ != false) {
+        output.writeBool(5, isScenarioTableDriven_);
+      }
+      if (scenarioDataTable_ != null) {
+        output.writeMessage(6, getScenarioDataTable());
+      }
+      if (scenarioTableRow_ != null) {
+        output.writeMessage(7, getScenarioTableRow());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -12856,6 +14387,26 @@ public final class Spec {
       if (tableRowIndex_ != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(2, tableRowIndex_);
+      }
+      if (scenarioTableRowIndex_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, scenarioTableRowIndex_);
+      }
+      if (isSpecTableDriven_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, isSpecTableDriven_);
+      }
+      if (isScenarioTableDriven_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(5, isScenarioTableDriven_);
+      }
+      if (scenarioDataTable_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, getScenarioDataTable());
+      }
+      if (scenarioTableRow_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(7, getScenarioTableRow());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -12880,6 +14431,22 @@ public final class Spec {
       }
       result = result && (getTableRowIndex()
           == other.getTableRowIndex());
+      result = result && (getScenarioTableRowIndex()
+          == other.getScenarioTableRowIndex());
+      result = result && (getIsSpecTableDriven()
+          == other.getIsSpecTableDriven());
+      result = result && (getIsScenarioTableDriven()
+          == other.getIsScenarioTableDriven());
+      result = result && (hasScenarioDataTable() == other.hasScenarioDataTable());
+      if (hasScenarioDataTable()) {
+        result = result && getScenarioDataTable()
+            .equals(other.getScenarioDataTable());
+      }
+      result = result && (hasScenarioTableRow() == other.hasScenarioTableRow());
+      if (hasScenarioTableRow()) {
+        result = result && getScenarioTableRow()
+            .equals(other.getScenarioTableRow());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -12897,6 +14464,22 @@ public final class Spec {
       }
       hash = (37 * hash) + TABLEROWINDEX_FIELD_NUMBER;
       hash = (53 * hash) + getTableRowIndex();
+      hash = (37 * hash) + SCENARIOTABLEROWINDEX_FIELD_NUMBER;
+      hash = (53 * hash) + getScenarioTableRowIndex();
+      hash = (37 * hash) + ISSPECTABLEDRIVEN_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getIsSpecTableDriven());
+      hash = (37 * hash) + ISSCENARIOTABLEDRIVEN_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getIsScenarioTableDriven());
+      if (hasScenarioDataTable()) {
+        hash = (37 * hash) + SCENARIODATATABLE_FIELD_NUMBER;
+        hash = (53 * hash) + getScenarioDataTable().hashCode();
+      }
+      if (hasScenarioTableRow()) {
+        hash = (37 * hash) + SCENARIOTABLEROW_FIELD_NUMBER;
+        hash = (53 * hash) + getScenarioTableRow().hashCode();
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -13042,6 +14625,24 @@ public final class Spec {
         }
         tableRowIndex_ = 0;
 
+        scenarioTableRowIndex_ = 0;
+
+        isSpecTableDriven_ = false;
+
+        isScenarioTableDriven_ = false;
+
+        if (scenarioDataTableBuilder_ == null) {
+          scenarioDataTable_ = null;
+        } else {
+          scenarioDataTable_ = null;
+          scenarioDataTableBuilder_ = null;
+        }
+        if (scenarioTableRowBuilder_ == null) {
+          scenarioTableRow_ = null;
+        } else {
+          scenarioTableRow_ = null;
+          scenarioTableRowBuilder_ = null;
+        }
         return this;
       }
 
@@ -13074,6 +14675,19 @@ public final class Spec {
           result.scenario_ = scenarioBuilder_.build();
         }
         result.tableRowIndex_ = tableRowIndex_;
+        result.scenarioTableRowIndex_ = scenarioTableRowIndex_;
+        result.isSpecTableDriven_ = isSpecTableDriven_;
+        result.isScenarioTableDriven_ = isScenarioTableDriven_;
+        if (scenarioDataTableBuilder_ == null) {
+          result.scenarioDataTable_ = scenarioDataTable_;
+        } else {
+          result.scenarioDataTable_ = scenarioDataTableBuilder_.build();
+        }
+        if (scenarioTableRowBuilder_ == null) {
+          result.scenarioTableRow_ = scenarioTableRow_;
+        } else {
+          result.scenarioTableRow_ = scenarioTableRowBuilder_.build();
+        }
         onBuilt();
         return result;
       }
@@ -13127,6 +14741,21 @@ public final class Spec {
         }
         if (other.getTableRowIndex() != 0) {
           setTableRowIndex(other.getTableRowIndex());
+        }
+        if (other.getScenarioTableRowIndex() != 0) {
+          setScenarioTableRowIndex(other.getScenarioTableRowIndex());
+        }
+        if (other.getIsSpecTableDriven() != false) {
+          setIsSpecTableDriven(other.getIsSpecTableDriven());
+        }
+        if (other.getIsScenarioTableDriven() != false) {
+          setIsScenarioTableDriven(other.getIsScenarioTableDriven());
+        }
+        if (other.hasScenarioDataTable()) {
+          mergeScenarioDataTable(other.getScenarioDataTable());
+        }
+        if (other.hasScenarioTableRow()) {
+          mergeScenarioTableRow(other.getScenarioTableRow());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -13346,6 +14975,426 @@ public final class Spec {
         tableRowIndex_ = 0;
         onChanged();
         return this;
+      }
+
+      private int scenarioTableRowIndex_ ;
+      /**
+       * <pre>
+       *&#47; Row Index of scenario data table against which the current scenario is executed
+       * </pre>
+       *
+       * <code>int32 scenarioTableRowIndex = 3;</code>
+       */
+      public int getScenarioTableRowIndex() {
+        return scenarioTableRowIndex_;
+      }
+      /**
+       * <pre>
+       *&#47; Row Index of scenario data table against which the current scenario is executed
+       * </pre>
+       *
+       * <code>int32 scenarioTableRowIndex = 3;</code>
+       */
+      public Builder setScenarioTableRowIndex(int value) {
+        
+        scenarioTableRowIndex_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Row Index of scenario data table against which the current scenario is executed
+       * </pre>
+       *
+       * <code>int32 scenarioTableRowIndex = 3;</code>
+       */
+      public Builder clearScenarioTableRowIndex() {
+        
+        scenarioTableRowIndex_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private boolean isSpecTableDriven_ ;
+      /**
+       * <pre>
+       *&#47; Executed against a spec data table
+       * </pre>
+       *
+       * <code>bool isSpecTableDriven = 4;</code>
+       */
+      public boolean getIsSpecTableDriven() {
+        return isSpecTableDriven_;
+      }
+      /**
+       * <pre>
+       *&#47; Executed against a spec data table
+       * </pre>
+       *
+       * <code>bool isSpecTableDriven = 4;</code>
+       */
+      public Builder setIsSpecTableDriven(boolean value) {
+        
+        isSpecTableDriven_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Executed against a spec data table
+       * </pre>
+       *
+       * <code>bool isSpecTableDriven = 4;</code>
+       */
+      public Builder clearIsSpecTableDriven() {
+        
+        isSpecTableDriven_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean isScenarioTableDriven_ ;
+      /**
+       * <pre>
+       *&#47; Executed against a scenario data table
+       * </pre>
+       *
+       * <code>bool isScenarioTableDriven = 5;</code>
+       */
+      public boolean getIsScenarioTableDriven() {
+        return isScenarioTableDriven_;
+      }
+      /**
+       * <pre>
+       *&#47; Executed against a scenario data table
+       * </pre>
+       *
+       * <code>bool isScenarioTableDriven = 5;</code>
+       */
+      public Builder setIsScenarioTableDriven(boolean value) {
+        
+        isScenarioTableDriven_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Executed against a scenario data table
+       * </pre>
+       *
+       * <code>bool isScenarioTableDriven = 5;</code>
+       */
+      public Builder clearIsScenarioTableDriven() {
+        
+        isScenarioTableDriven_ = false;
+        onChanged();
+        return this;
+      }
+
+      private gauge.messages.Spec.ProtoTable scenarioDataTable_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoTable, gauge.messages.Spec.ProtoTable.Builder, gauge.messages.Spec.ProtoTableOrBuilder> scenarioDataTableBuilder_;
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public boolean hasScenarioDataTable() {
+        return scenarioDataTableBuilder_ != null || scenarioDataTable_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public gauge.messages.Spec.ProtoTable getScenarioDataTable() {
+        if (scenarioDataTableBuilder_ == null) {
+          return scenarioDataTable_ == null ? gauge.messages.Spec.ProtoTable.getDefaultInstance() : scenarioDataTable_;
+        } else {
+          return scenarioDataTableBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public Builder setScenarioDataTable(gauge.messages.Spec.ProtoTable value) {
+        if (scenarioDataTableBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          scenarioDataTable_ = value;
+          onChanged();
+        } else {
+          scenarioDataTableBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public Builder setScenarioDataTable(
+          gauge.messages.Spec.ProtoTable.Builder builderForValue) {
+        if (scenarioDataTableBuilder_ == null) {
+          scenarioDataTable_ = builderForValue.build();
+          onChanged();
+        } else {
+          scenarioDataTableBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public Builder mergeScenarioDataTable(gauge.messages.Spec.ProtoTable value) {
+        if (scenarioDataTableBuilder_ == null) {
+          if (scenarioDataTable_ != null) {
+            scenarioDataTable_ =
+              gauge.messages.Spec.ProtoTable.newBuilder(scenarioDataTable_).mergeFrom(value).buildPartial();
+          } else {
+            scenarioDataTable_ = value;
+          }
+          onChanged();
+        } else {
+          scenarioDataTableBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public Builder clearScenarioDataTable() {
+        if (scenarioDataTableBuilder_ == null) {
+          scenarioDataTable_ = null;
+          onChanged();
+        } else {
+          scenarioDataTable_ = null;
+          scenarioDataTableBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public gauge.messages.Spec.ProtoTable.Builder getScenarioDataTableBuilder() {
+        
+        onChanged();
+        return getScenarioDataTableFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      public gauge.messages.Spec.ProtoTableOrBuilder getScenarioDataTableOrBuilder() {
+        if (scenarioDataTableBuilder_ != null) {
+          return scenarioDataTableBuilder_.getMessageOrBuilder();
+        } else {
+          return scenarioDataTable_ == null ?
+              gauge.messages.Spec.ProtoTable.getDefaultInstance() : scenarioDataTable_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the scenario data table
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioDataTable = 6;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoTable, gauge.messages.Spec.ProtoTable.Builder, gauge.messages.Spec.ProtoTableOrBuilder> 
+          getScenarioDataTableFieldBuilder() {
+        if (scenarioDataTableBuilder_ == null) {
+          scenarioDataTableBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoTable, gauge.messages.Spec.ProtoTable.Builder, gauge.messages.Spec.ProtoTableOrBuilder>(
+                  getScenarioDataTable(),
+                  getParentForChildren(),
+                  isClean());
+          scenarioDataTable_ = null;
+        }
+        return scenarioDataTableBuilder_;
+      }
+
+      private gauge.messages.Spec.ProtoTable scenarioTableRow_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoTable, gauge.messages.Spec.ProtoTable.Builder, gauge.messages.Spec.ProtoTableOrBuilder> scenarioTableRowBuilder_;
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public boolean hasScenarioTableRow() {
+        return scenarioTableRowBuilder_ != null || scenarioTableRow_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public gauge.messages.Spec.ProtoTable getScenarioTableRow() {
+        if (scenarioTableRowBuilder_ == null) {
+          return scenarioTableRow_ == null ? gauge.messages.Spec.ProtoTable.getDefaultInstance() : scenarioTableRow_;
+        } else {
+          return scenarioTableRowBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public Builder setScenarioTableRow(gauge.messages.Spec.ProtoTable value) {
+        if (scenarioTableRowBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          scenarioTableRow_ = value;
+          onChanged();
+        } else {
+          scenarioTableRowBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public Builder setScenarioTableRow(
+          gauge.messages.Spec.ProtoTable.Builder builderForValue) {
+        if (scenarioTableRowBuilder_ == null) {
+          scenarioTableRow_ = builderForValue.build();
+          onChanged();
+        } else {
+          scenarioTableRowBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public Builder mergeScenarioTableRow(gauge.messages.Spec.ProtoTable value) {
+        if (scenarioTableRowBuilder_ == null) {
+          if (scenarioTableRow_ != null) {
+            scenarioTableRow_ =
+              gauge.messages.Spec.ProtoTable.newBuilder(scenarioTableRow_).mergeFrom(value).buildPartial();
+          } else {
+            scenarioTableRow_ = value;
+          }
+          onChanged();
+        } else {
+          scenarioTableRowBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public Builder clearScenarioTableRow() {
+        if (scenarioTableRowBuilder_ == null) {
+          scenarioTableRow_ = null;
+          onChanged();
+        } else {
+          scenarioTableRow_ = null;
+          scenarioTableRowBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public gauge.messages.Spec.ProtoTable.Builder getScenarioTableRowBuilder() {
+        
+        onChanged();
+        return getScenarioTableRowFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      public gauge.messages.Spec.ProtoTableOrBuilder getScenarioTableRowOrBuilder() {
+        if (scenarioTableRowBuilder_ != null) {
+          return scenarioTableRowBuilder_.getMessageOrBuilder();
+        } else {
+          return scenarioTableRow_ == null ?
+              gauge.messages.Spec.ProtoTable.getDefaultInstance() : scenarioTableRow_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Hold the row of scenario data table.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoTable scenarioTableRow = 7;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoTable, gauge.messages.Spec.ProtoTable.Builder, gauge.messages.Spec.ProtoTableOrBuilder> 
+          getScenarioTableRowFieldBuilder() {
+        if (scenarioTableRowBuilder_ == null) {
+          scenarioTableRowBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoTable, gauge.messages.Spec.ProtoTable.Builder, gauge.messages.Spec.ProtoTableOrBuilder>(
+                  getScenarioTableRow(),
+                  getParentForChildren(),
+                  isClean());
+          scenarioTableRow_ = null;
+        }
+        return scenarioTableRowBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -13581,53 +15630,123 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 7;</code>
+     * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 7;</code>
+     * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
      */
-    int getPreHookScreenshotsCount();
+    @java.lang.Deprecated int getPreHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 7;</code>
+     * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPreHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPreHookScreenshots(int index);
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 8;</code>
+     * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 8;</code>
+     * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
      */
-    int getPostHookScreenshotsCount();
+    @java.lang.Deprecated int getPostHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 8;</code>
+     * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPostHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPostHookScreenshots(int index);
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    java.util.List<java.lang.String>
+        getPreHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    int getPreHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    java.lang.String getPreHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index);
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    java.util.List<java.lang.String>
+        getPostHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    int getPostHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    java.lang.String getPostHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index);
   }
   /**
    * <pre>
@@ -13653,6 +15772,8 @@ public final class Spec {
       postHookMessages_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       preHookScreenshots_ = java.util.Collections.emptyList();
       postHookScreenshots_ = java.util.Collections.emptyList();
+      preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -13747,6 +15868,24 @@ public final class Spec {
               postHookScreenshots_.add(input.readBytes());
               break;
             }
+            case 74: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
+                preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000100;
+              }
+              preHookScreenshotFiles_.add(s);
+              break;
+            }
+            case 82: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000200) == 0x00000200)) {
+                postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000200;
+              }
+              postHookScreenshotFiles_.add(s);
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -13776,6 +15915,12 @@ public final class Spec {
         }
         if (((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
           postHookScreenshots_ = java.util.Collections.unmodifiableList(postHookScreenshots_);
+        }
+        if (((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00000200) == 0x00000200)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -14061,33 +16206,33 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> preHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 7;</code>
+     * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPreHookScreenshotsList() {
       return preHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 7;</code>
+     * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
      */
-    public int getPreHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPreHookScreenshotsCount() {
       return preHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 7;</code>
+     * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
       return preHookScreenshots_.get(index);
     }
 
@@ -14095,34 +16240,124 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> postHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 8;</code>
+     * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPostHookScreenshotsList() {
       return postHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 8;</code>
+     * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
      */
-    public int getPostHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPostHookScreenshotsCount() {
       return postHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 8;</code>
+     * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
       return postHookScreenshots_.get(index);
+    }
+
+    public static final int PREHOOKSCREENSHOTFILES_FIELD_NUMBER = 9;
+    private com.google.protobuf.LazyStringList preHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPreHookScreenshotFilesList() {
+      return preHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    public int getPreHookScreenshotFilesCount() {
+      return preHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    public java.lang.String getPreHookScreenshotFiles(int index) {
+      return preHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 9;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index) {
+      return preHookScreenshotFiles_.getByteString(index);
+    }
+
+    public static final int POSTHOOKSCREENSHOTFILES_FIELD_NUMBER = 10;
+    private com.google.protobuf.LazyStringList postHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPostHookScreenshotFilesList() {
+      return postHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    public int getPostHookScreenshotFilesCount() {
+      return postHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    public java.lang.String getPostHookScreenshotFiles(int index) {
+      return postHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 10;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index) {
+      return postHookScreenshotFiles_.getByteString(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -14162,6 +16397,12 @@ public final class Spec {
       }
       for (int i = 0; i < postHookScreenshots_.size(); i++) {
         output.writeBytes(8, postHookScreenshots_.get(i));
+      }
+      for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 9, preHookScreenshotFiles_.getRaw(i));
+      }
+      for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 10, postHookScreenshotFiles_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -14220,6 +16461,22 @@ public final class Spec {
         size += dataSize;
         size += 1 * getPostHookScreenshotsList().size();
       }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(preHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getPreHookScreenshotFilesList().size();
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(postHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getPostHookScreenshotFilesList().size();
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -14255,6 +16512,10 @@ public final class Spec {
           .equals(other.getPreHookScreenshotsList());
       result = result && getPostHookScreenshotsList()
           .equals(other.getPostHookScreenshotsList());
+      result = result && getPreHookScreenshotFilesList()
+          .equals(other.getPreHookScreenshotFilesList());
+      result = result && getPostHookScreenshotFilesList()
+          .equals(other.getPostHookScreenshotFilesList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -14293,6 +16554,14 @@ public final class Spec {
       if (getPostHookScreenshotsCount() > 0) {
         hash = (37 * hash) + POSTHOOKSCREENSHOTS_FIELD_NUMBER;
         hash = (53 * hash) + getPostHookScreenshotsList().hashCode();
+      }
+      if (getPreHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + PREHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPreHookScreenshotFilesList().hashCode();
+      }
+      if (getPostHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + POSTHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPostHookScreenshotFilesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -14456,6 +16725,10 @@ public final class Spec {
         bitField0_ = (bitField0_ & ~0x00000040);
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000080);
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000100);
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -14520,6 +16793,16 @@ public final class Spec {
           bitField0_ = (bitField0_ & ~0x00000080);
         }
         result.postHookScreenshots_ = postHookScreenshots_;
+        if (((bitField0_ & 0x00000100) == 0x00000100)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000100);
+        }
+        result.preHookScreenshotFiles_ = preHookScreenshotFiles_;
+        if (((bitField0_ & 0x00000200) == 0x00000200)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000200);
+        }
+        result.postHookScreenshotFiles_ = postHookScreenshotFiles_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -14643,6 +16926,26 @@ public final class Spec {
           } else {
             ensurePostHookScreenshotsIsMutable();
             postHookScreenshots_.addAll(other.postHookScreenshots_);
+          }
+          onChanged();
+        }
+        if (!other.preHookScreenshotFiles_.isEmpty()) {
+          if (preHookScreenshotFiles_.isEmpty()) {
+            preHookScreenshotFiles_ = other.preHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00000100);
+          } else {
+            ensurePreHookScreenshotFilesIsMutable();
+            preHookScreenshotFiles_.addAll(other.preHookScreenshotFiles_);
+          }
+          onChanged();
+        }
+        if (!other.postHookScreenshotFiles_.isEmpty()) {
+          if (postHookScreenshotFiles_.isEmpty()) {
+            postHookScreenshotFiles_ = other.postHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00000200);
+          } else {
+            ensurePostHookScreenshotFilesIsMutable();
+            postHookScreenshotFiles_.addAll(other.postHookScreenshotFiles_);
           }
           onChanged();
         }
@@ -15588,43 +17891,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPreHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(preHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public int getPreHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPreHookScreenshotsCount() {
         return preHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
         return preHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public Builder setPreHookScreenshots(
+      @java.lang.Deprecated public Builder setPreHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -15636,12 +17939,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -15652,12 +17955,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public Builder addAllPreHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPreHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePreHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -15667,12 +17970,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 7;</code>
+       * <code>repeated bytes preHookScreenshots = 7 [deprecated = true];</code>
        */
-      public Builder clearPreHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPreHookScreenshots() {
         preHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000040);
         onChanged();
@@ -15688,43 +17991,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPostHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(postHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public int getPostHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPostHookScreenshotsCount() {
         return postHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
         return postHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public Builder setPostHookScreenshots(
+      @java.lang.Deprecated public Builder setPostHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -15736,12 +18039,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -15752,12 +18055,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public Builder addAllPostHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPostHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePostHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -15767,14 +18070,274 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 8;</code>
+       * <code>repeated bytes postHookScreenshots = 8 [deprecated = true];</code>
        */
-      public Builder clearPostHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPostHookScreenshots() {
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000080);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePreHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00000100) == 0x00000100)) {
+          preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(preHookScreenshotFiles_);
+          bitField0_ |= 0x00000100;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPreHookScreenshotFilesList() {
+        return preHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public int getPreHookScreenshotFilesCount() {
+        return preHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public java.lang.String getPreHookScreenshotFiles(int index) {
+        return preHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPreHookScreenshotFilesBytes(int index) {
+        return preHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public Builder setPreHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public Builder addPreHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public Builder addAllPreHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePreHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, preHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public Builder clearPreHookScreenshotFiles() {
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000100);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 9;</code>
+       */
+      public Builder addPreHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePostHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00000200) == 0x00000200)) {
+          postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(postHookScreenshotFiles_);
+          bitField0_ |= 0x00000200;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPostHookScreenshotFilesList() {
+        return postHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public int getPostHookScreenshotFilesCount() {
+        return postHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public java.lang.String getPostHookScreenshotFiles(int index) {
+        return postHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPostHookScreenshotFilesBytes(int index) {
+        return postHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public Builder setPostHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public Builder addPostHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public Builder addAllPostHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePostHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, postHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public Builder clearPostHookScreenshotFiles() {
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000200);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 10;</code>
+       */
+      public Builder addPostHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
         onChanged();
         return this;
       }
@@ -24223,7 +26786,7 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; [DEPRECATED, use failedScreenshot] Bytes containing screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
      * </pre>
      *
      * <code>bytes screenShot = 5 [deprecated = true];</code>
@@ -24293,37 +26856,90 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; Bytes containing screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
      * </pre>
      *
-     * <code>bytes failureScreenshot = 9;</code>
+     * <code>bytes failureScreenshot = 9 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getFailureScreenshot();
+    @java.lang.Deprecated com.google.protobuf.ByteString getFailureScreenshot();
 
     /**
      * <pre>
-     *&#47; Bytes array containing screenshots at the time of it invoked
+     *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
      * </pre>
      *
-     * <code>repeated bytes screenshots = 10;</code>
+     * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getScreenshotsList();
     /**
      * <pre>
-     *&#47; Bytes array containing screenshots at the time of it invoked
+     *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
      * </pre>
      *
-     * <code>repeated bytes screenshots = 10;</code>
+     * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
      */
-    int getScreenshotsCount();
+    @java.lang.Deprecated int getScreenshotsCount();
     /**
      * <pre>
-     *&#47; Bytes array containing screenshots at the time of it invoked
+     *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
      * </pre>
      *
-     * <code>repeated bytes screenshots = 10;</code>
+     * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getScreenshots(int index);
+
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 11;</code>
+     */
+    java.lang.String getFailureScreenshotFile();
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 11;</code>
+     */
+    com.google.protobuf.ByteString
+        getFailureScreenshotFileBytes();
+
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    java.util.List<java.lang.String>
+        getScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    int getScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    java.lang.String getScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    com.google.protobuf.ByteString
+        getScreenshotFilesBytes(int index);
   }
   /**
    * <pre>
@@ -24352,6 +26968,8 @@ public final class Spec {
       errorType_ = 0;
       failureScreenshot_ = com.google.protobuf.ByteString.EMPTY;
       screenshots_ = java.util.Collections.emptyList();
+      failureScreenshotFile_ = "";
+      screenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -24438,6 +27056,21 @@ public final class Spec {
               screenshots_.add(input.readBytes());
               break;
             }
+            case 90: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              failureScreenshotFile_ = s;
+              break;
+            }
+            case 98: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
+                screenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000800;
+              }
+              screenshotFiles_.add(s);
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -24458,6 +27091,9 @@ public final class Spec {
         }
         if (((mutable_bitField0_ & 0x00000200) == 0x00000200)) {
           screenshots_ = java.util.Collections.unmodifiableList(screenshots_);
+        }
+        if (((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
+          screenshotFiles_ = screenshotFiles_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -24689,7 +27325,7 @@ public final class Spec {
     private com.google.protobuf.ByteString screenShot_;
     /**
      * <pre>
-     *&#47; [DEPRECATED, use failedScreenshot] Bytes containing screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
      * </pre>
      *
      * <code>bytes screenShot = 5 [deprecated = true];</code>
@@ -24785,12 +27421,12 @@ public final class Spec {
     private com.google.protobuf.ByteString failureScreenshot_;
     /**
      * <pre>
-     *&#47; Bytes containing screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
      * </pre>
      *
-     * <code>bytes failureScreenshot = 9;</code>
+     * <code>bytes failureScreenshot = 9 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getFailureScreenshot() {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getFailureScreenshot() {
       return failureScreenshot_;
     }
 
@@ -24798,34 +27434,121 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> screenshots_;
     /**
      * <pre>
-     *&#47; Bytes array containing screenshots at the time of it invoked
+     *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
      * </pre>
      *
-     * <code>repeated bytes screenshots = 10;</code>
+     * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getScreenshotsList() {
       return screenshots_;
     }
     /**
      * <pre>
-     *&#47; Bytes array containing screenshots at the time of it invoked
+     *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
      * </pre>
      *
-     * <code>repeated bytes screenshots = 10;</code>
+     * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
      */
-    public int getScreenshotsCount() {
+    @java.lang.Deprecated public int getScreenshotsCount() {
       return screenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Bytes array containing screenshots at the time of it invoked
+     *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
      * </pre>
      *
-     * <code>repeated bytes screenshots = 10;</code>
+     * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getScreenshots(int index) {
       return screenshots_.get(index);
+    }
+
+    public static final int FAILURESCREENSHOTFILE_FIELD_NUMBER = 11;
+    private volatile java.lang.Object failureScreenshotFile_;
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 11;</code>
+     */
+    public java.lang.String getFailureScreenshotFile() {
+      java.lang.Object ref = failureScreenshotFile_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        failureScreenshotFile_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 11;</code>
+     */
+    public com.google.protobuf.ByteString
+        getFailureScreenshotFileBytes() {
+      java.lang.Object ref = failureScreenshotFile_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        failureScreenshotFile_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int SCREENSHOTFILES_FIELD_NUMBER = 12;
+    private com.google.protobuf.LazyStringList screenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getScreenshotFilesList() {
+      return screenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    public int getScreenshotFilesCount() {
+      return screenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    public java.lang.String getScreenshotFiles(int index) {
+      return screenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+     * </pre>
+     *
+     * <code>repeated string screenshotFiles = 12;</code>
+     */
+    public com.google.protobuf.ByteString
+        getScreenshotFilesBytes(int index) {
+      return screenshotFiles_.getByteString(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -24871,6 +27594,12 @@ public final class Spec {
       }
       for (int i = 0; i < screenshots_.size(); i++) {
         output.writeBytes(10, screenshots_.get(i));
+      }
+      if (!getFailureScreenshotFileBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 11, failureScreenshotFile_);
+      }
+      for (int i = 0; i < screenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 12, screenshotFiles_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -24928,6 +27657,17 @@ public final class Spec {
         size += dataSize;
         size += 1 * getScreenshotsList().size();
       }
+      if (!getFailureScreenshotFileBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(11, failureScreenshotFile_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < screenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(screenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getScreenshotFilesList().size();
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -24963,6 +27703,10 @@ public final class Spec {
           .equals(other.getFailureScreenshot());
       result = result && getScreenshotsList()
           .equals(other.getScreenshotsList());
+      result = result && getFailureScreenshotFile()
+          .equals(other.getFailureScreenshotFile());
+      result = result && getScreenshotFilesList()
+          .equals(other.getScreenshotFilesList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -25000,6 +27744,12 @@ public final class Spec {
       if (getScreenshotsCount() > 0) {
         hash = (37 * hash) + SCREENSHOTS_FIELD_NUMBER;
         hash = (53 * hash) + getScreenshotsList().hashCode();
+      }
+      hash = (37 * hash) + FAILURESCREENSHOTFILE_FIELD_NUMBER;
+      hash = (53 * hash) + getFailureScreenshotFile().hashCode();
+      if (getScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + SCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getScreenshotFilesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -25158,6 +27908,10 @@ public final class Spec {
 
         screenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000200);
+        failureScreenshotFile_ = "";
+
+        screenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000800);
         return this;
       }
 
@@ -25204,6 +27958,12 @@ public final class Spec {
           bitField0_ = (bitField0_ & ~0x00000200);
         }
         result.screenshots_ = screenshots_;
+        result.failureScreenshotFile_ = failureScreenshotFile_;
+        if (((bitField0_ & 0x00000800) == 0x00000800)) {
+          screenshotFiles_ = screenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000800);
+        }
+        result.screenshotFiles_ = screenshotFiles_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -25296,6 +28056,20 @@ public final class Spec {
           } else {
             ensureScreenshotsIsMutable();
             screenshots_.addAll(other.screenshots_);
+          }
+          onChanged();
+        }
+        if (!other.getFailureScreenshotFile().isEmpty()) {
+          failureScreenshotFile_ = other.failureScreenshotFile_;
+          onChanged();
+        }
+        if (!other.screenshotFiles_.isEmpty()) {
+          if (screenshotFiles_.isEmpty()) {
+            screenshotFiles_ = other.screenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00000800);
+          } else {
+            ensureScreenshotFilesIsMutable();
+            screenshotFiles_.addAll(other.screenshotFiles_);
           }
           onChanged();
         }
@@ -25586,7 +28360,7 @@ public final class Spec {
       private com.google.protobuf.ByteString screenShot_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <pre>
-       *&#47; [DEPRECATED, use failedScreenshot] Bytes containing screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
        * </pre>
        *
        * <code>bytes screenShot = 5 [deprecated = true];</code>
@@ -25596,7 +28370,7 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; [DEPRECATED, use failedScreenshot] Bytes containing screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
        * </pre>
        *
        * <code>bytes screenShot = 5 [deprecated = true];</code>
@@ -25612,7 +28386,7 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; [DEPRECATED, use failedScreenshot] Bytes containing screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
        * </pre>
        *
        * <code>bytes screenShot = 5 [deprecated = true];</code>
@@ -25860,22 +28634,22 @@ public final class Spec {
       private com.google.protobuf.ByteString failureScreenshot_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <pre>
-       *&#47; Bytes containing screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
        * </pre>
        *
-       * <code>bytes failureScreenshot = 9;</code>
+       * <code>bytes failureScreenshot = 9 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getFailureScreenshot() {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getFailureScreenshot() {
         return failureScreenshot_;
       }
       /**
        * <pre>
-       *&#47; Bytes containing screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
        * </pre>
        *
-       * <code>bytes failureScreenshot = 9;</code>
+       * <code>bytes failureScreenshot = 9 [deprecated = true];</code>
        */
-      public Builder setFailureScreenshot(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder setFailureScreenshot(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -25886,12 +28660,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Bytes containing screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes containing screenshot taken at the time of failure.
        * </pre>
        *
-       * <code>bytes failureScreenshot = 9;</code>
+       * <code>bytes failureScreenshot = 9 [deprecated = true];</code>
        */
-      public Builder clearFailureScreenshot() {
+      @java.lang.Deprecated public Builder clearFailureScreenshot() {
         
         failureScreenshot_ = getDefaultInstance().getFailureScreenshot();
         onChanged();
@@ -25907,43 +28681,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getScreenshotsList() {
         return java.util.Collections.unmodifiableList(screenshots_);
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public int getScreenshotsCount() {
+      @java.lang.Deprecated public int getScreenshotsCount() {
         return screenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getScreenshots(int index) {
         return screenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public Builder setScreenshots(
+      @java.lang.Deprecated public Builder setScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -25955,12 +28729,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public Builder addScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -25971,12 +28745,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public Builder addAllScreenshots(
+      @java.lang.Deprecated public Builder addAllScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensureScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -25986,14 +28760,233 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Bytes array containing screenshots at the time of it invoked
+       *&#47; [DEPRECATED, use screenshotFiles] Bytes array containing screenshots at the time of it invoked
        * </pre>
        *
-       * <code>repeated bytes screenshots = 10;</code>
+       * <code>repeated bytes screenshots = 10 [deprecated = true];</code>
        */
-      public Builder clearScreenshots() {
+      @java.lang.Deprecated public Builder clearScreenshots() {
         screenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000200);
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object failureScreenshotFile_ = "";
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 11;</code>
+       */
+      public java.lang.String getFailureScreenshotFile() {
+        java.lang.Object ref = failureScreenshotFile_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          failureScreenshotFile_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 11;</code>
+       */
+      public com.google.protobuf.ByteString
+          getFailureScreenshotFileBytes() {
+        java.lang.Object ref = failureScreenshotFile_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          failureScreenshotFile_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 11;</code>
+       */
+      public Builder setFailureScreenshotFile(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        failureScreenshotFile_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 11;</code>
+       */
+      public Builder clearFailureScreenshotFile() {
+        
+        failureScreenshotFile_ = getDefaultInstance().getFailureScreenshotFile();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 11;</code>
+       */
+      public Builder setFailureScreenshotFileBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        failureScreenshotFile_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList screenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00000800) == 0x00000800)) {
+          screenshotFiles_ = new com.google.protobuf.LazyStringArrayList(screenshotFiles_);
+          bitField0_ |= 0x00000800;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getScreenshotFilesList() {
+        return screenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public int getScreenshotFilesCount() {
+        return screenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public java.lang.String getScreenshotFiles(int index) {
+        return screenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public com.google.protobuf.ByteString
+          getScreenshotFilesBytes(int index) {
+        return screenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public Builder setScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureScreenshotFilesIsMutable();
+        screenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public Builder addScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureScreenshotFilesIsMutable();
+        screenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public Builder addAllScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, screenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public Builder clearScreenshotFiles() {
+        screenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000800);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot files captured using Gauge screenshsot API.
+       * </pre>
+       *
+       * <code>repeated string screenshotFiles = 12;</code>
+       */
+      public Builder addScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureScreenshotFilesIsMutable();
+        screenshotFiles_.add(value);
         onChanged();
         return this;
       }
@@ -26092,7 +29085,7 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; [DEPRECATED, use failedScreenshot] Bytes holding the screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
      * </pre>
      *
      * <code>bytes screenShot = 3 [deprecated = true];</code>
@@ -26110,12 +29103,30 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47;Bytes holding the screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
      * </pre>
      *
-     * <code>bytes failureScreenshot = 5;</code>
+     * <code>bytes failureScreenshot = 5 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getFailureScreenshot();
+    @java.lang.Deprecated com.google.protobuf.ByteString getFailureScreenshot();
+
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 6;</code>
+     */
+    java.lang.String getFailureScreenshotFile();
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 6;</code>
+     */
+    com.google.protobuf.ByteString
+        getFailureScreenshotFileBytes();
   }
   /**
    * <pre>
@@ -26140,6 +29151,7 @@ public final class Spec {
       screenShot_ = com.google.protobuf.ByteString.EMPTY;
       tableRowIndex_ = 0;
       failureScreenshot_ = com.google.protobuf.ByteString.EMPTY;
+      failureScreenshotFile_ = "";
     }
 
     @java.lang.Override
@@ -26191,6 +29203,12 @@ public final class Spec {
             case 42: {
 
               failureScreenshot_ = input.readBytes();
+              break;
+            }
+            case 50: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              failureScreenshotFile_ = s;
               break;
             }
             default: {
@@ -26313,7 +29331,7 @@ public final class Spec {
     private com.google.protobuf.ByteString screenShot_;
     /**
      * <pre>
-     *&#47; [DEPRECATED, use failedScreenshot] Bytes holding the screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
      * </pre>
      *
      * <code>bytes screenShot = 3 [deprecated = true];</code>
@@ -26339,13 +29357,55 @@ public final class Spec {
     private com.google.protobuf.ByteString failureScreenshot_;
     /**
      * <pre>
-     *&#47;Bytes holding the screenshot taken at the time of failure.
+     *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
      * </pre>
      *
-     * <code>bytes failureScreenshot = 5;</code>
+     * <code>bytes failureScreenshot = 5 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getFailureScreenshot() {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getFailureScreenshot() {
       return failureScreenshot_;
+    }
+
+    public static final int FAILURESCREENSHOTFILE_FIELD_NUMBER = 6;
+    private volatile java.lang.Object failureScreenshotFile_;
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 6;</code>
+     */
+    public java.lang.String getFailureScreenshotFile() {
+      java.lang.Object ref = failureScreenshotFile_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        failureScreenshotFile_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Path to the screenshot file captured at the time of failure.
+     * </pre>
+     *
+     * <code>string failureScreenshotFile = 6;</code>
+     */
+    public com.google.protobuf.ByteString
+        getFailureScreenshotFileBytes() {
+      java.lang.Object ref = failureScreenshotFile_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        failureScreenshotFile_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -26377,6 +29437,9 @@ public final class Spec {
       if (!failureScreenshot_.isEmpty()) {
         output.writeBytes(5, failureScreenshot_);
       }
+      if (!getFailureScreenshotFileBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, failureScreenshotFile_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -26404,6 +29467,9 @@ public final class Spec {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, failureScreenshot_);
       }
+      if (!getFailureScreenshotFileBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, failureScreenshotFile_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -26430,6 +29496,8 @@ public final class Spec {
           == other.getTableRowIndex());
       result = result && getFailureScreenshot()
           .equals(other.getFailureScreenshot());
+      result = result && getFailureScreenshotFile()
+          .equals(other.getFailureScreenshotFile());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -26451,6 +29519,8 @@ public final class Spec {
       hash = (53 * hash) + getTableRowIndex();
       hash = (37 * hash) + FAILURESCREENSHOT_FIELD_NUMBER;
       hash = (53 * hash) + getFailureScreenshot().hashCode();
+      hash = (37 * hash) + FAILURESCREENSHOTFILE_FIELD_NUMBER;
+      hash = (53 * hash) + getFailureScreenshotFile().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -26599,6 +29669,8 @@ public final class Spec {
 
         failureScreenshot_ = com.google.protobuf.ByteString.EMPTY;
 
+        failureScreenshotFile_ = "";
+
         return this;
       }
 
@@ -26630,6 +29702,7 @@ public final class Spec {
         result.screenShot_ = screenShot_;
         result.tableRowIndex_ = tableRowIndex_;
         result.failureScreenshot_ = failureScreenshot_;
+        result.failureScreenshotFile_ = failureScreenshotFile_;
         onBuilt();
         return result;
       }
@@ -26694,6 +29767,10 @@ public final class Spec {
         }
         if (other.getFailureScreenshot() != com.google.protobuf.ByteString.EMPTY) {
           setFailureScreenshot(other.getFailureScreenshot());
+        }
+        if (!other.getFailureScreenshotFile().isEmpty()) {
+          failureScreenshotFile_ = other.failureScreenshotFile_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -26905,7 +29982,7 @@ public final class Spec {
       private com.google.protobuf.ByteString screenShot_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <pre>
-       *&#47; [DEPRECATED, use failedScreenshot] Bytes holding the screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
        * </pre>
        *
        * <code>bytes screenShot = 3 [deprecated = true];</code>
@@ -26915,7 +29992,7 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; [DEPRECATED, use failedScreenshot] Bytes holding the screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
        * </pre>
        *
        * <code>bytes screenShot = 3 [deprecated = true];</code>
@@ -26931,7 +30008,7 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; [DEPRECATED, use failedScreenshot] Bytes holding the screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
        * </pre>
        *
        * <code>bytes screenShot = 3 [deprecated = true];</code>
@@ -26984,22 +30061,22 @@ public final class Spec {
       private com.google.protobuf.ByteString failureScreenshot_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <pre>
-       *&#47;Bytes holding the screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
        * </pre>
        *
-       * <code>bytes failureScreenshot = 5;</code>
+       * <code>bytes failureScreenshot = 5 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getFailureScreenshot() {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getFailureScreenshot() {
         return failureScreenshot_;
       }
       /**
        * <pre>
-       *&#47;Bytes holding the screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
        * </pre>
        *
-       * <code>bytes failureScreenshot = 5;</code>
+       * <code>bytes failureScreenshot = 5 [deprecated = true];</code>
        */
-      public Builder setFailureScreenshot(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder setFailureScreenshot(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -27010,14 +30087,103 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47;Bytes holding the screenshot taken at the time of failure.
+       *&#47; [DEPRECATED, use failureScreenshotFile] Bytes holding the screenshot taken at the time of failure.
        * </pre>
        *
-       * <code>bytes failureScreenshot = 5;</code>
+       * <code>bytes failureScreenshot = 5 [deprecated = true];</code>
        */
-      public Builder clearFailureScreenshot() {
+      @java.lang.Deprecated public Builder clearFailureScreenshot() {
         
         failureScreenshot_ = getDefaultInstance().getFailureScreenshot();
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object failureScreenshotFile_ = "";
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 6;</code>
+       */
+      public java.lang.String getFailureScreenshotFile() {
+        java.lang.Object ref = failureScreenshotFile_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          failureScreenshotFile_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 6;</code>
+       */
+      public com.google.protobuf.ByteString
+          getFailureScreenshotFileBytes() {
+        java.lang.Object ref = failureScreenshotFile_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          failureScreenshotFile_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 6;</code>
+       */
+      public Builder setFailureScreenshotFile(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        failureScreenshotFile_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 6;</code>
+       */
+      public Builder clearFailureScreenshotFile() {
+        
+        failureScreenshotFile_ = getDefaultInstance().getFailureScreenshotFile();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Path to the screenshot file captured at the time of failure.
+       * </pre>
+       *
+       * <code>string failureScreenshotFile = 6;</code>
+       */
+      public Builder setFailureScreenshotFileBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        failureScreenshotFile_ = value;
         onChanged();
         return this;
       }
@@ -27427,53 +30593,141 @@ public final class Spec {
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 17;</code>
+     * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPreHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 17;</code>
+     * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
      */
-    int getPreHookScreenshotsCount();
+    @java.lang.Deprecated int getPreHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 17;</code>
+     * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPreHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPreHookScreenshots(int index);
 
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 18;</code>
+     * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
      */
-    java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
+    @java.lang.Deprecated java.util.List<com.google.protobuf.ByteString> getPostHookScreenshotsList();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 18;</code>
+     * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
      */
-    int getPostHookScreenshotsCount();
+    @java.lang.Deprecated int getPostHookScreenshotsCount();
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 18;</code>
+     * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString getPostHookScreenshots(int index);
+    @java.lang.Deprecated com.google.protobuf.ByteString getPostHookScreenshots(int index);
+
+    /**
+     * <pre>
+     * Indicates if the result is sent in chunks
+     * </pre>
+     *
+     * <code>bool chunked = 19;</code>
+     */
+    boolean getChunked();
+
+    /**
+     * <pre>
+     * Indicates the number of chunks to expect after this
+     * </pre>
+     *
+     * <code>int64 chunkSize = 20;</code>
+     */
+    long getChunkSize();
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    java.util.List<java.lang.String>
+        getPreHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    int getPreHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    java.lang.String getPreHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index);
+
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    java.util.List<java.lang.String>
+        getPostHookScreenshotFilesList();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    int getPostHookScreenshotFilesCount();
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    java.lang.String getPostHookScreenshotFiles(int index);
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index);
   }
   /**
    * <pre>
@@ -27508,6 +30762,10 @@ public final class Spec {
       postHookMessage_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       preHookScreenshots_ = java.util.Collections.emptyList();
       postHookScreenshots_ = java.util.Collections.emptyList();
+      chunked_ = false;
+      chunkSize_ = 0L;
+      preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -27670,6 +30928,34 @@ public final class Spec {
               postHookScreenshots_.add(input.readBytes());
               break;
             }
+            case 152: {
+
+              chunked_ = input.readBool();
+              break;
+            }
+            case 160: {
+
+              chunkSize_ = input.readInt64();
+              break;
+            }
+            case 170: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00100000) == 0x00100000)) {
+                preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00100000;
+              }
+              preHookScreenshotFiles_.add(s);
+              break;
+            }
+            case 178: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00200000) == 0x00200000)) {
+                postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00200000;
+              }
+              postHookScreenshotFiles_.add(s);
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -27705,6 +30991,12 @@ public final class Spec {
         }
         if (((mutable_bitField0_ & 0x00020000) == 0x00020000)) {
           postHookScreenshots_ = java.util.Collections.unmodifiableList(postHookScreenshots_);
+        }
+        if (((mutable_bitField0_ & 0x00100000) == 0x00100000)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00200000) == 0x00200000)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -28258,33 +31550,33 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> preHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 17;</code>
+     * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPreHookScreenshotsList() {
       return preHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 17;</code>
+     * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
      */
-    public int getPreHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPreHookScreenshotsCount() {
       return preHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at pre hook exec time to be available on reports
+     *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes preHookScreenshots = 17;</code>
+     * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
       return preHookScreenshots_.get(index);
     }
 
@@ -28292,34 +31584,150 @@ public final class Spec {
     private java.util.List<com.google.protobuf.ByteString> postHookScreenshots_;
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 18;</code>
+     * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
      */
-    public java.util.List<com.google.protobuf.ByteString>
+    @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
         getPostHookScreenshotsList() {
       return postHookScreenshots_;
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 18;</code>
+     * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
      */
-    public int getPostHookScreenshotsCount() {
+    @java.lang.Deprecated public int getPostHookScreenshotsCount() {
       return postHookScreenshots_.size();
     }
     /**
      * <pre>
-     *&#47; Capture Screenshot at post hook exec time to be available on reports
+     *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
      * </pre>
      *
-     * <code>repeated bytes postHookScreenshots = 18;</code>
+     * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+    @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
       return postHookScreenshots_.get(index);
+    }
+
+    public static final int CHUNKED_FIELD_NUMBER = 19;
+    private boolean chunked_;
+    /**
+     * <pre>
+     * Indicates if the result is sent in chunks
+     * </pre>
+     *
+     * <code>bool chunked = 19;</code>
+     */
+    public boolean getChunked() {
+      return chunked_;
+    }
+
+    public static final int CHUNKSIZE_FIELD_NUMBER = 20;
+    private long chunkSize_;
+    /**
+     * <pre>
+     * Indicates the number of chunks to expect after this
+     * </pre>
+     *
+     * <code>int64 chunkSize = 20;</code>
+     */
+    public long getChunkSize() {
+      return chunkSize_;
+    }
+
+    public static final int PREHOOKSCREENSHOTFILES_FIELD_NUMBER = 21;
+    private com.google.protobuf.LazyStringList preHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPreHookScreenshotFilesList() {
+      return preHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public int getPreHookScreenshotFilesCount() {
+      return preHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public java.lang.String getPreHookScreenshotFiles(int index) {
+      return preHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on pre hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string preHookScreenshotFiles = 21;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPreHookScreenshotFilesBytes(int index) {
+      return preHookScreenshotFiles_.getByteString(index);
+    }
+
+    public static final int POSTHOOKSCREENSHOTFILES_FIELD_NUMBER = 22;
+    private com.google.protobuf.LazyStringList postHookScreenshotFiles_;
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getPostHookScreenshotFilesList() {
+      return postHookScreenshotFiles_;
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public int getPostHookScreenshotFilesCount() {
+      return postHookScreenshotFiles_.size();
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public java.lang.String getPostHookScreenshotFiles(int index) {
+      return postHookScreenshotFiles_.get(index);
+    }
+    /**
+     * <pre>
+     *&#47; Screenshots captured on post hook exec time to be available on reports
+     * </pre>
+     *
+     * <code>repeated string postHookScreenshotFiles = 22;</code>
+     */
+    public com.google.protobuf.ByteString
+        getPostHookScreenshotFilesBytes(int index) {
+      return postHookScreenshotFiles_.getByteString(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -28389,6 +31797,18 @@ public final class Spec {
       }
       for (int i = 0; i < postHookScreenshots_.size(); i++) {
         output.writeBytes(18, postHookScreenshots_.get(i));
+      }
+      if (chunked_ != false) {
+        output.writeBool(19, chunked_);
+      }
+      if (chunkSize_ != 0L) {
+        output.writeInt64(20, chunkSize_);
+      }
+      for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 21, preHookScreenshotFiles_.getRaw(i));
+      }
+      for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 22, postHookScreenshotFiles_.getRaw(i));
       }
       unknownFields.writeTo(output);
     }
@@ -28493,6 +31913,30 @@ public final class Spec {
         size += dataSize;
         size += 2 * getPostHookScreenshotsList().size();
       }
+      if (chunked_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(19, chunked_);
+      }
+      if (chunkSize_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(20, chunkSize_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < preHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(preHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getPreHookScreenshotFilesList().size();
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < postHookScreenshotFiles_.size(); i++) {
+          dataSize += computeStringSizeNoTag(postHookScreenshotFiles_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getPostHookScreenshotFilesList().size();
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -28553,6 +31997,14 @@ public final class Spec {
           .equals(other.getPreHookScreenshotsList());
       result = result && getPostHookScreenshotsList()
           .equals(other.getPostHookScreenshotsList());
+      result = result && (getChunked()
+          == other.getChunked());
+      result = result && (getChunkSize()
+          == other.getChunkSize());
+      result = result && getPreHookScreenshotFilesList()
+          .equals(other.getPreHookScreenshotFilesList());
+      result = result && getPostHookScreenshotFilesList()
+          .equals(other.getPostHookScreenshotFilesList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -28620,6 +32072,20 @@ public final class Spec {
       if (getPostHookScreenshotsCount() > 0) {
         hash = (37 * hash) + POSTHOOKSCREENSHOTS_FIELD_NUMBER;
         hash = (53 * hash) + getPostHookScreenshotsList().hashCode();
+      }
+      hash = (37 * hash) + CHUNKED_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getChunked());
+      hash = (37 * hash) + CHUNKSIZE_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getChunkSize());
+      if (getPreHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + PREHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPreHookScreenshotFilesList().hashCode();
+      }
+      if (getPostHookScreenshotFilesCount() > 0) {
+        hash = (37 * hash) + POSTHOOKSCREENSHOTFILES_FIELD_NUMBER;
+        hash = (53 * hash) + getPostHookScreenshotFilesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -28807,6 +32273,14 @@ public final class Spec {
         bitField0_ = (bitField0_ & ~0x00010000);
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00020000);
+        chunked_ = false;
+
+        chunkSize_ = 0L;
+
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00100000);
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
 
@@ -28893,6 +32367,18 @@ public final class Spec {
           bitField0_ = (bitField0_ & ~0x00020000);
         }
         result.postHookScreenshots_ = postHookScreenshots_;
+        result.chunked_ = chunked_;
+        result.chunkSize_ = chunkSize_;
+        if (((bitField0_ & 0x00100000) == 0x00100000)) {
+          preHookScreenshotFiles_ = preHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00100000);
+        }
+        result.preHookScreenshotFiles_ = preHookScreenshotFiles_;
+        if (((bitField0_ & 0x00200000) == 0x00200000)) {
+          postHookScreenshotFiles_ = postHookScreenshotFiles_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00200000);
+        }
+        result.postHookScreenshotFiles_ = postHookScreenshotFiles_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -29062,6 +32548,32 @@ public final class Spec {
           } else {
             ensurePostHookScreenshotsIsMutable();
             postHookScreenshots_.addAll(other.postHookScreenshots_);
+          }
+          onChanged();
+        }
+        if (other.getChunked() != false) {
+          setChunked(other.getChunked());
+        }
+        if (other.getChunkSize() != 0L) {
+          setChunkSize(other.getChunkSize());
+        }
+        if (!other.preHookScreenshotFiles_.isEmpty()) {
+          if (preHookScreenshotFiles_.isEmpty()) {
+            preHookScreenshotFiles_ = other.preHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00100000);
+          } else {
+            ensurePreHookScreenshotFilesIsMutable();
+            preHookScreenshotFiles_.addAll(other.preHookScreenshotFiles_);
+          }
+          onChanged();
+        }
+        if (!other.postHookScreenshotFiles_.isEmpty()) {
+          if (postHookScreenshotFiles_.isEmpty()) {
+            postHookScreenshotFiles_ = other.postHookScreenshotFiles_;
+            bitField0_ = (bitField0_ & ~0x00200000);
+          } else {
+            ensurePostHookScreenshotFilesIsMutable();
+            postHookScreenshotFiles_.addAll(other.postHookScreenshotFiles_);
           }
           onChanged();
         }
@@ -30776,43 +34288,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPreHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(preHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public int getPreHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPreHookScreenshotsCount() {
         return preHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPreHookScreenshots(int index) {
         return preHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public Builder setPreHookScreenshots(
+      @java.lang.Deprecated public Builder setPreHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -30824,12 +34336,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPreHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -30840,12 +34352,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public Builder addAllPreHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPreHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePreHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -30855,12 +34367,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at pre hook exec time to be available on reports
+       *&#47; [DEPRECATED, use preHookScreenshotFiles] Capture Screenshot at pre hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes preHookScreenshots = 17;</code>
+       * <code>repeated bytes preHookScreenshots = 17 [deprecated = true];</code>
        */
-      public Builder clearPreHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPreHookScreenshots() {
         preHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00010000);
         onChanged();
@@ -30876,43 +34388,43 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public java.util.List<com.google.protobuf.ByteString>
+      @java.lang.Deprecated public java.util.List<com.google.protobuf.ByteString>
           getPostHookScreenshotsList() {
         return java.util.Collections.unmodifiableList(postHookScreenshots_);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public int getPostHookScreenshotsCount() {
+      @java.lang.Deprecated public int getPostHookScreenshotsCount() {
         return postHookScreenshots_.size();
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
+      @java.lang.Deprecated public com.google.protobuf.ByteString getPostHookScreenshots(int index) {
         return postHookScreenshots_.get(index);
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public Builder setPostHookScreenshots(
+      @java.lang.Deprecated public Builder setPostHookScreenshots(
           int index, com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -30924,12 +34436,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder addPostHookScreenshots(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -30940,12 +34452,12 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public Builder addAllPostHookScreenshots(
+      @java.lang.Deprecated public Builder addAllPostHookScreenshots(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensurePostHookScreenshotsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -30955,14 +34467,350 @@ public final class Spec {
       }
       /**
        * <pre>
-       *&#47; Capture Screenshot at post hook exec time to be available on reports
+       *&#47; [DEPRECATED, use postHookScreenshotFiles] Capture Screenshot at post hook exec time to be available on reports
        * </pre>
        *
-       * <code>repeated bytes postHookScreenshots = 18;</code>
+       * <code>repeated bytes postHookScreenshots = 18 [deprecated = true];</code>
        */
-      public Builder clearPostHookScreenshots() {
+      @java.lang.Deprecated public Builder clearPostHookScreenshots() {
         postHookScreenshots_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00020000);
+        onChanged();
+        return this;
+      }
+
+      private boolean chunked_ ;
+      /**
+       * <pre>
+       * Indicates if the result is sent in chunks
+       * </pre>
+       *
+       * <code>bool chunked = 19;</code>
+       */
+      public boolean getChunked() {
+        return chunked_;
+      }
+      /**
+       * <pre>
+       * Indicates if the result is sent in chunks
+       * </pre>
+       *
+       * <code>bool chunked = 19;</code>
+       */
+      public Builder setChunked(boolean value) {
+        
+        chunked_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Indicates if the result is sent in chunks
+       * </pre>
+       *
+       * <code>bool chunked = 19;</code>
+       */
+      public Builder clearChunked() {
+        
+        chunked_ = false;
+        onChanged();
+        return this;
+      }
+
+      private long chunkSize_ ;
+      /**
+       * <pre>
+       * Indicates the number of chunks to expect after this
+       * </pre>
+       *
+       * <code>int64 chunkSize = 20;</code>
+       */
+      public long getChunkSize() {
+        return chunkSize_;
+      }
+      /**
+       * <pre>
+       * Indicates the number of chunks to expect after this
+       * </pre>
+       *
+       * <code>int64 chunkSize = 20;</code>
+       */
+      public Builder setChunkSize(long value) {
+        
+        chunkSize_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Indicates the number of chunks to expect after this
+       * </pre>
+       *
+       * <code>int64 chunkSize = 20;</code>
+       */
+      public Builder clearChunkSize() {
+        
+        chunkSize_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePreHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00100000) == 0x00100000)) {
+          preHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(preHookScreenshotFiles_);
+          bitField0_ |= 0x00100000;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPreHookScreenshotFilesList() {
+        return preHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public int getPreHookScreenshotFilesCount() {
+        return preHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public java.lang.String getPreHookScreenshotFiles(int index) {
+        return preHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPreHookScreenshotFilesBytes(int index) {
+        return preHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder setPreHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder addPreHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder addAllPreHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePreHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, preHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder clearPreHookScreenshotFiles() {
+        preHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00100000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on pre hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string preHookScreenshotFiles = 21;</code>
+       */
+      public Builder addPreHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePreHookScreenshotFilesIsMutable();
+        preHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensurePostHookScreenshotFilesIsMutable() {
+        if (!((bitField0_ & 0x00200000) == 0x00200000)) {
+          postHookScreenshotFiles_ = new com.google.protobuf.LazyStringArrayList(postHookScreenshotFiles_);
+          bitField0_ |= 0x00200000;
+         }
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getPostHookScreenshotFilesList() {
+        return postHookScreenshotFiles_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public int getPostHookScreenshotFilesCount() {
+        return postHookScreenshotFiles_.size();
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public java.lang.String getPostHookScreenshotFiles(int index) {
+        return postHookScreenshotFiles_.get(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public com.google.protobuf.ByteString
+          getPostHookScreenshotFilesBytes(int index) {
+        return postHookScreenshotFiles_.getByteString(index);
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder setPostHookScreenshotFiles(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder addPostHookScreenshotFiles(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder addAllPostHookScreenshotFiles(
+          java.lang.Iterable<java.lang.String> values) {
+        ensurePostHookScreenshotFilesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, postHookScreenshotFiles_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder clearPostHookScreenshotFiles() {
+        postHookScreenshotFiles_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00200000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Screenshots captured on post hook exec time to be available on reports
+       * </pre>
+       *
+       * <code>repeated string postHookScreenshotFiles = 22;</code>
+       */
+      public Builder addPostHookScreenshotFilesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensurePostHookScreenshotFilesIsMutable();
+        postHookScreenshotFiles_.add(value);
         onChanged();
         return this;
       }
@@ -31195,6 +35043,24 @@ public final class Spec {
      */
     gauge.messages.Spec.ErrorOrBuilder getErrorsOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 11;</code>
+     */
+    java.lang.String getTimestamp();
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 11;</code>
+     */
+    com.google.protobuf.ByteString
+        getTimestampBytes();
   }
   /**
    * <pre>
@@ -31222,6 +35088,7 @@ public final class Spec {
       scenarioSkippedCount_ = 0;
       skippedDataTableRows_ = java.util.Collections.emptyList();
       errors_ = java.util.Collections.emptyList();
+      timestamp_ = "";
     }
 
     @java.lang.Override
@@ -31340,6 +35207,12 @@ public final class Spec {
               }
               errors_.add(
                   input.readMessage(gauge.messages.Spec.Error.parser(), extensionRegistry));
+              break;
+            }
+            case 90: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              timestamp_ = s;
               break;
             }
             default: {
@@ -31620,6 +35493,48 @@ public final class Spec {
       return errors_.get(index);
     }
 
+    public static final int TIMESTAMP_FIELD_NUMBER = 11;
+    private volatile java.lang.Object timestamp_;
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 11;</code>
+     */
+    public java.lang.String getTimestamp() {
+      java.lang.Object ref = timestamp_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        timestamp_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 11;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTimestampBytes() {
+      java.lang.Object ref = timestamp_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        timestamp_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -31672,6 +35587,9 @@ public final class Spec {
       }
       for (int i = 0; i < errors_.size(); i++) {
         output.writeMessage(10, errors_.get(i));
+      }
+      if (!getTimestampBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 11, timestamp_);
       }
       unknownFields.writeTo(output);
     }
@@ -31742,6 +35660,9 @@ public final class Spec {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(10, errors_.get(i));
       }
+      if (!getTimestampBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(11, timestamp_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -31781,6 +35702,8 @@ public final class Spec {
           .equals(other.getSkippedDataTableRowsList());
       result = result && getErrorsList()
           .equals(other.getErrorsList());
+      result = result && getTimestamp()
+          .equals(other.getTimestamp());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -31823,6 +35746,8 @@ public final class Spec {
         hash = (37 * hash) + ERRORS_FIELD_NUMBER;
         hash = (53 * hash) + getErrorsList().hashCode();
       }
+      hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
+      hash = (53 * hash) + getTimestamp().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -31989,6 +35914,8 @@ public final class Spec {
         } else {
           errorsBuilder_.clear();
         }
+        timestamp_ = "";
+
         return this;
       }
 
@@ -32047,6 +35974,7 @@ public final class Spec {
         } else {
           result.errors_ = errorsBuilder_.build();
         }
+        result.timestamp_ = timestamp_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -32162,6 +36090,10 @@ public final class Spec {
               errorsBuilder_.addAllMessages(other.errors_);
             }
           }
+        }
+        if (!other.getTimestamp().isEmpty()) {
+          timestamp_ = other.timestamp_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -33073,6 +37005,95 @@ public final class Spec {
         }
         return errorsBuilder_;
       }
+
+      private java.lang.Object timestamp_ = "";
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 11;</code>
+       */
+      public java.lang.String getTimestamp() {
+        java.lang.Object ref = timestamp_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          timestamp_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 11;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTimestampBytes() {
+        java.lang.Object ref = timestamp_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          timestamp_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 11;</code>
+       */
+      public Builder setTimestamp(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        timestamp_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 11;</code>
+       */
+      public Builder clearTimestamp() {
+        
+        timestamp_ = getDefaultInstance().getTimestamp();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 11;</code>
+       */
+      public Builder setTimestampBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        timestamp_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -33121,6 +37142,1870 @@ public final class Spec {
 
     @java.lang.Override
     public gauge.messages.Spec.ProtoSpecResult getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ProtoScenarioResultOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gauge.messages.ProtoScenarioResult)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     *&#47; Collection of scenarios in scenario execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    boolean hasProtoItem();
+    /**
+     * <pre>
+     *&#47; Collection of scenarios in scenario execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    gauge.messages.Spec.ProtoItem getProtoItem();
+    /**
+     * <pre>
+     *&#47; Collection of scenarios in scenario execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    gauge.messages.Spec.ProtoItemOrBuilder getProtoItemOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the time taken for executing the whole suite.
+     * </pre>
+     *
+     * <code>int64 executionTime = 2;</code>
+     */
+    long getExecutionTime();
+
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    java.lang.String getTimestamp();
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getTimestampBytes();
+  }
+  /**
+   * <pre>
+   *&#47; A proto object representing the result of Scenario execution.
+   * </pre>
+   *
+   * Protobuf type {@code gauge.messages.ProtoScenarioResult}
+   */
+  public  static final class ProtoScenarioResult extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:gauge.messages.ProtoScenarioResult)
+      ProtoScenarioResultOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ProtoScenarioResult.newBuilder() to construct.
+    private ProtoScenarioResult(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ProtoScenarioResult() {
+      executionTime_ = 0L;
+      timestamp_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ProtoScenarioResult(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              gauge.messages.Spec.ProtoItem.Builder subBuilder = null;
+              if (protoItem_ != null) {
+                subBuilder = protoItem_.toBuilder();
+              }
+              protoItem_ = input.readMessage(gauge.messages.Spec.ProtoItem.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(protoItem_);
+                protoItem_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 16: {
+
+              executionTime_ = input.readInt64();
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              timestamp_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return gauge.messages.Spec.internal_static_gauge_messages_ProtoScenarioResult_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return gauge.messages.Spec.internal_static_gauge_messages_ProtoScenarioResult_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              gauge.messages.Spec.ProtoScenarioResult.class, gauge.messages.Spec.ProtoScenarioResult.Builder.class);
+    }
+
+    public static final int PROTOITEM_FIELD_NUMBER = 1;
+    private gauge.messages.Spec.ProtoItem protoItem_;
+    /**
+     * <pre>
+     *&#47; Collection of scenarios in scenario execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    public boolean hasProtoItem() {
+      return protoItem_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Collection of scenarios in scenario execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    public gauge.messages.Spec.ProtoItem getProtoItem() {
+      return protoItem_ == null ? gauge.messages.Spec.ProtoItem.getDefaultInstance() : protoItem_;
+    }
+    /**
+     * <pre>
+     *&#47; Collection of scenarios in scenario execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    public gauge.messages.Spec.ProtoItemOrBuilder getProtoItemOrBuilder() {
+      return getProtoItem();
+    }
+
+    public static final int EXECUTIONTIME_FIELD_NUMBER = 2;
+    private long executionTime_;
+    /**
+     * <pre>
+     *&#47; Holds the time taken for executing the whole suite.
+     * </pre>
+     *
+     * <code>int64 executionTime = 2;</code>
+     */
+    public long getExecutionTime() {
+      return executionTime_;
+    }
+
+    public static final int TIMESTAMP_FIELD_NUMBER = 3;
+    private volatile java.lang.Object timestamp_;
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    public java.lang.String getTimestamp() {
+      java.lang.Object ref = timestamp_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        timestamp_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTimestampBytes() {
+      java.lang.Object ref = timestamp_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        timestamp_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (protoItem_ != null) {
+        output.writeMessage(1, getProtoItem());
+      }
+      if (executionTime_ != 0L) {
+        output.writeInt64(2, executionTime_);
+      }
+      if (!getTimestampBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, timestamp_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (protoItem_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getProtoItem());
+      }
+      if (executionTime_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, executionTime_);
+      }
+      if (!getTimestampBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, timestamp_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof gauge.messages.Spec.ProtoScenarioResult)) {
+        return super.equals(obj);
+      }
+      gauge.messages.Spec.ProtoScenarioResult other = (gauge.messages.Spec.ProtoScenarioResult) obj;
+
+      boolean result = true;
+      result = result && (hasProtoItem() == other.hasProtoItem());
+      if (hasProtoItem()) {
+        result = result && getProtoItem()
+            .equals(other.getProtoItem());
+      }
+      result = result && (getExecutionTime()
+          == other.getExecutionTime());
+      result = result && getTimestamp()
+          .equals(other.getTimestamp());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasProtoItem()) {
+        hash = (37 * hash) + PROTOITEM_FIELD_NUMBER;
+        hash = (53 * hash) + getProtoItem().hashCode();
+      }
+      hash = (37 * hash) + EXECUTIONTIME_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getExecutionTime());
+      hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
+      hash = (53 * hash) + getTimestamp().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Spec.ProtoScenarioResult parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(gauge.messages.Spec.ProtoScenarioResult prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *&#47; A proto object representing the result of Scenario execution.
+     * </pre>
+     *
+     * Protobuf type {@code gauge.messages.ProtoScenarioResult}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gauge.messages.ProtoScenarioResult)
+        gauge.messages.Spec.ProtoScenarioResultOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return gauge.messages.Spec.internal_static_gauge_messages_ProtoScenarioResult_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return gauge.messages.Spec.internal_static_gauge_messages_ProtoScenarioResult_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                gauge.messages.Spec.ProtoScenarioResult.class, gauge.messages.Spec.ProtoScenarioResult.Builder.class);
+      }
+
+      // Construct using gauge.messages.Spec.ProtoScenarioResult.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (protoItemBuilder_ == null) {
+          protoItem_ = null;
+        } else {
+          protoItem_ = null;
+          protoItemBuilder_ = null;
+        }
+        executionTime_ = 0L;
+
+        timestamp_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return gauge.messages.Spec.internal_static_gauge_messages_ProtoScenarioResult_descriptor;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Spec.ProtoScenarioResult getDefaultInstanceForType() {
+        return gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public gauge.messages.Spec.ProtoScenarioResult build() {
+        gauge.messages.Spec.ProtoScenarioResult result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Spec.ProtoScenarioResult buildPartial() {
+        gauge.messages.Spec.ProtoScenarioResult result = new gauge.messages.Spec.ProtoScenarioResult(this);
+        if (protoItemBuilder_ == null) {
+          result.protoItem_ = protoItem_;
+        } else {
+          result.protoItem_ = protoItemBuilder_.build();
+        }
+        result.executionTime_ = executionTime_;
+        result.timestamp_ = timestamp_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof gauge.messages.Spec.ProtoScenarioResult) {
+          return mergeFrom((gauge.messages.Spec.ProtoScenarioResult)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(gauge.messages.Spec.ProtoScenarioResult other) {
+        if (other == gauge.messages.Spec.ProtoScenarioResult.getDefaultInstance()) return this;
+        if (other.hasProtoItem()) {
+          mergeProtoItem(other.getProtoItem());
+        }
+        if (other.getExecutionTime() != 0L) {
+          setExecutionTime(other.getExecutionTime());
+        }
+        if (!other.getTimestamp().isEmpty()) {
+          timestamp_ = other.timestamp_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        gauge.messages.Spec.ProtoScenarioResult parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (gauge.messages.Spec.ProtoScenarioResult) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private gauge.messages.Spec.ProtoItem protoItem_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder> protoItemBuilder_;
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public boolean hasProtoItem() {
+        return protoItemBuilder_ != null || protoItem_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItem getProtoItem() {
+        if (protoItemBuilder_ == null) {
+          return protoItem_ == null ? gauge.messages.Spec.ProtoItem.getDefaultInstance() : protoItem_;
+        } else {
+          return protoItemBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder setProtoItem(gauge.messages.Spec.ProtoItem value) {
+        if (protoItemBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          protoItem_ = value;
+          onChanged();
+        } else {
+          protoItemBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder setProtoItem(
+          gauge.messages.Spec.ProtoItem.Builder builderForValue) {
+        if (protoItemBuilder_ == null) {
+          protoItem_ = builderForValue.build();
+          onChanged();
+        } else {
+          protoItemBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder mergeProtoItem(gauge.messages.Spec.ProtoItem value) {
+        if (protoItemBuilder_ == null) {
+          if (protoItem_ != null) {
+            protoItem_ =
+              gauge.messages.Spec.ProtoItem.newBuilder(protoItem_).mergeFrom(value).buildPartial();
+          } else {
+            protoItem_ = value;
+          }
+          onChanged();
+        } else {
+          protoItemBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder clearProtoItem() {
+        if (protoItemBuilder_ == null) {
+          protoItem_ = null;
+          onChanged();
+        } else {
+          protoItem_ = null;
+          protoItemBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItem.Builder getProtoItemBuilder() {
+        
+        onChanged();
+        return getProtoItemFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItemOrBuilder getProtoItemOrBuilder() {
+        if (protoItemBuilder_ != null) {
+          return protoItemBuilder_.getMessageOrBuilder();
+        } else {
+          return protoItem_ == null ?
+              gauge.messages.Spec.ProtoItem.getDefaultInstance() : protoItem_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Collection of scenarios in scenario execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder> 
+          getProtoItemFieldBuilder() {
+        if (protoItemBuilder_ == null) {
+          protoItemBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder>(
+                  getProtoItem(),
+                  getParentForChildren(),
+                  isClean());
+          protoItem_ = null;
+        }
+        return protoItemBuilder_;
+      }
+
+      private long executionTime_ ;
+      /**
+       * <pre>
+       *&#47; Holds the time taken for executing the whole suite.
+       * </pre>
+       *
+       * <code>int64 executionTime = 2;</code>
+       */
+      public long getExecutionTime() {
+        return executionTime_;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the time taken for executing the whole suite.
+       * </pre>
+       *
+       * <code>int64 executionTime = 2;</code>
+       */
+      public Builder setExecutionTime(long value) {
+        
+        executionTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the time taken for executing the whole suite.
+       * </pre>
+       *
+       * <code>int64 executionTime = 2;</code>
+       */
+      public Builder clearExecutionTime() {
+        
+        executionTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object timestamp_ = "";
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public java.lang.String getTimestamp() {
+        java.lang.Object ref = timestamp_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          timestamp_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTimestampBytes() {
+        java.lang.Object ref = timestamp_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          timestamp_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public Builder setTimestamp(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        timestamp_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public Builder clearTimestamp() {
+        
+        timestamp_ = getDefaultInstance().getTimestamp();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public Builder setTimestampBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        timestamp_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:gauge.messages.ProtoScenarioResult)
+    }
+
+    // @@protoc_insertion_point(class_scope:gauge.messages.ProtoScenarioResult)
+    private static final gauge.messages.Spec.ProtoScenarioResult DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new gauge.messages.Spec.ProtoScenarioResult();
+    }
+
+    public static gauge.messages.Spec.ProtoScenarioResult getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ProtoScenarioResult>
+        PARSER = new com.google.protobuf.AbstractParser<ProtoScenarioResult>() {
+      @java.lang.Override
+      public ProtoScenarioResult parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ProtoScenarioResult(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ProtoScenarioResult> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ProtoScenarioResult> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public gauge.messages.Spec.ProtoScenarioResult getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ProtoStepResultOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gauge.messages.ProtoStepResult)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     *&#47; Collection of steps in step execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    boolean hasProtoItem();
+    /**
+     * <pre>
+     *&#47; Collection of steps in step execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    gauge.messages.Spec.ProtoItem getProtoItem();
+    /**
+     * <pre>
+     *&#47; Collection of steps in step execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    gauge.messages.Spec.ProtoItemOrBuilder getProtoItemOrBuilder();
+
+    /**
+     * <pre>
+     *&#47; Holds the time taken for executing the whole suite.
+     * </pre>
+     *
+     * <code>int64 executionTime = 2;</code>
+     */
+    long getExecutionTime();
+
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    java.lang.String getTimestamp();
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getTimestampBytes();
+  }
+  /**
+   * <pre>
+   *&#47; A proto object representing the result of Step execution.
+   * </pre>
+   *
+   * Protobuf type {@code gauge.messages.ProtoStepResult}
+   */
+  public  static final class ProtoStepResult extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:gauge.messages.ProtoStepResult)
+      ProtoStepResultOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ProtoStepResult.newBuilder() to construct.
+    private ProtoStepResult(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ProtoStepResult() {
+      executionTime_ = 0L;
+      timestamp_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ProtoStepResult(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              gauge.messages.Spec.ProtoItem.Builder subBuilder = null;
+              if (protoItem_ != null) {
+                subBuilder = protoItem_.toBuilder();
+              }
+              protoItem_ = input.readMessage(gauge.messages.Spec.ProtoItem.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(protoItem_);
+                protoItem_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 16: {
+
+              executionTime_ = input.readInt64();
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              timestamp_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return gauge.messages.Spec.internal_static_gauge_messages_ProtoStepResult_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return gauge.messages.Spec.internal_static_gauge_messages_ProtoStepResult_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              gauge.messages.Spec.ProtoStepResult.class, gauge.messages.Spec.ProtoStepResult.Builder.class);
+    }
+
+    public static final int PROTOITEM_FIELD_NUMBER = 1;
+    private gauge.messages.Spec.ProtoItem protoItem_;
+    /**
+     * <pre>
+     *&#47; Collection of steps in step execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    public boolean hasProtoItem() {
+      return protoItem_ != null;
+    }
+    /**
+     * <pre>
+     *&#47; Collection of steps in step execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    public gauge.messages.Spec.ProtoItem getProtoItem() {
+      return protoItem_ == null ? gauge.messages.Spec.ProtoItem.getDefaultInstance() : protoItem_;
+    }
+    /**
+     * <pre>
+     *&#47; Collection of steps in step execution result.
+     * </pre>
+     *
+     * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+     */
+    public gauge.messages.Spec.ProtoItemOrBuilder getProtoItemOrBuilder() {
+      return getProtoItem();
+    }
+
+    public static final int EXECUTIONTIME_FIELD_NUMBER = 2;
+    private long executionTime_;
+    /**
+     * <pre>
+     *&#47; Holds the time taken for executing the whole suite.
+     * </pre>
+     *
+     * <code>int64 executionTime = 2;</code>
+     */
+    public long getExecutionTime() {
+      return executionTime_;
+    }
+
+    public static final int TIMESTAMP_FIELD_NUMBER = 3;
+    private volatile java.lang.Object timestamp_;
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    public java.lang.String getTimestamp() {
+      java.lang.Object ref = timestamp_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        timestamp_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *&#47; Holds the timestamp of event starting.
+     * </pre>
+     *
+     * <code>string timestamp = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTimestampBytes() {
+      java.lang.Object ref = timestamp_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        timestamp_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (protoItem_ != null) {
+        output.writeMessage(1, getProtoItem());
+      }
+      if (executionTime_ != 0L) {
+        output.writeInt64(2, executionTime_);
+      }
+      if (!getTimestampBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, timestamp_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (protoItem_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getProtoItem());
+      }
+      if (executionTime_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, executionTime_);
+      }
+      if (!getTimestampBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, timestamp_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof gauge.messages.Spec.ProtoStepResult)) {
+        return super.equals(obj);
+      }
+      gauge.messages.Spec.ProtoStepResult other = (gauge.messages.Spec.ProtoStepResult) obj;
+
+      boolean result = true;
+      result = result && (hasProtoItem() == other.hasProtoItem());
+      if (hasProtoItem()) {
+        result = result && getProtoItem()
+            .equals(other.getProtoItem());
+      }
+      result = result && (getExecutionTime()
+          == other.getExecutionTime());
+      result = result && getTimestamp()
+          .equals(other.getTimestamp());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasProtoItem()) {
+        hash = (37 * hash) + PROTOITEM_FIELD_NUMBER;
+        hash = (53 * hash) + getProtoItem().hashCode();
+      }
+      hash = (37 * hash) + EXECUTIONTIME_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getExecutionTime());
+      hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
+      hash = (53 * hash) + getTimestamp().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static gauge.messages.Spec.ProtoStepResult parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(gauge.messages.Spec.ProtoStepResult prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *&#47; A proto object representing the result of Step execution.
+     * </pre>
+     *
+     * Protobuf type {@code gauge.messages.ProtoStepResult}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gauge.messages.ProtoStepResult)
+        gauge.messages.Spec.ProtoStepResultOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return gauge.messages.Spec.internal_static_gauge_messages_ProtoStepResult_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return gauge.messages.Spec.internal_static_gauge_messages_ProtoStepResult_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                gauge.messages.Spec.ProtoStepResult.class, gauge.messages.Spec.ProtoStepResult.Builder.class);
+      }
+
+      // Construct using gauge.messages.Spec.ProtoStepResult.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (protoItemBuilder_ == null) {
+          protoItem_ = null;
+        } else {
+          protoItem_ = null;
+          protoItemBuilder_ = null;
+        }
+        executionTime_ = 0L;
+
+        timestamp_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return gauge.messages.Spec.internal_static_gauge_messages_ProtoStepResult_descriptor;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Spec.ProtoStepResult getDefaultInstanceForType() {
+        return gauge.messages.Spec.ProtoStepResult.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public gauge.messages.Spec.ProtoStepResult build() {
+        gauge.messages.Spec.ProtoStepResult result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public gauge.messages.Spec.ProtoStepResult buildPartial() {
+        gauge.messages.Spec.ProtoStepResult result = new gauge.messages.Spec.ProtoStepResult(this);
+        if (protoItemBuilder_ == null) {
+          result.protoItem_ = protoItem_;
+        } else {
+          result.protoItem_ = protoItemBuilder_.build();
+        }
+        result.executionTime_ = executionTime_;
+        result.timestamp_ = timestamp_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof gauge.messages.Spec.ProtoStepResult) {
+          return mergeFrom((gauge.messages.Spec.ProtoStepResult)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(gauge.messages.Spec.ProtoStepResult other) {
+        if (other == gauge.messages.Spec.ProtoStepResult.getDefaultInstance()) return this;
+        if (other.hasProtoItem()) {
+          mergeProtoItem(other.getProtoItem());
+        }
+        if (other.getExecutionTime() != 0L) {
+          setExecutionTime(other.getExecutionTime());
+        }
+        if (!other.getTimestamp().isEmpty()) {
+          timestamp_ = other.timestamp_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        gauge.messages.Spec.ProtoStepResult parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (gauge.messages.Spec.ProtoStepResult) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private gauge.messages.Spec.ProtoItem protoItem_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder> protoItemBuilder_;
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public boolean hasProtoItem() {
+        return protoItemBuilder_ != null || protoItem_ != null;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItem getProtoItem() {
+        if (protoItemBuilder_ == null) {
+          return protoItem_ == null ? gauge.messages.Spec.ProtoItem.getDefaultInstance() : protoItem_;
+        } else {
+          return protoItemBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder setProtoItem(gauge.messages.Spec.ProtoItem value) {
+        if (protoItemBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          protoItem_ = value;
+          onChanged();
+        } else {
+          protoItemBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder setProtoItem(
+          gauge.messages.Spec.ProtoItem.Builder builderForValue) {
+        if (protoItemBuilder_ == null) {
+          protoItem_ = builderForValue.build();
+          onChanged();
+        } else {
+          protoItemBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder mergeProtoItem(gauge.messages.Spec.ProtoItem value) {
+        if (protoItemBuilder_ == null) {
+          if (protoItem_ != null) {
+            protoItem_ =
+              gauge.messages.Spec.ProtoItem.newBuilder(protoItem_).mergeFrom(value).buildPartial();
+          } else {
+            protoItem_ = value;
+          }
+          onChanged();
+        } else {
+          protoItemBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public Builder clearProtoItem() {
+        if (protoItemBuilder_ == null) {
+          protoItem_ = null;
+          onChanged();
+        } else {
+          protoItem_ = null;
+          protoItemBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItem.Builder getProtoItemBuilder() {
+        
+        onChanged();
+        return getProtoItemFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      public gauge.messages.Spec.ProtoItemOrBuilder getProtoItemOrBuilder() {
+        if (protoItemBuilder_ != null) {
+          return protoItemBuilder_.getMessageOrBuilder();
+        } else {
+          return protoItem_ == null ?
+              gauge.messages.Spec.ProtoItem.getDefaultInstance() : protoItem_;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Collection of steps in step execution result.
+       * </pre>
+       *
+       * <code>.gauge.messages.ProtoItem protoItem = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder> 
+          getProtoItemFieldBuilder() {
+        if (protoItemBuilder_ == null) {
+          protoItemBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              gauge.messages.Spec.ProtoItem, gauge.messages.Spec.ProtoItem.Builder, gauge.messages.Spec.ProtoItemOrBuilder>(
+                  getProtoItem(),
+                  getParentForChildren(),
+                  isClean());
+          protoItem_ = null;
+        }
+        return protoItemBuilder_;
+      }
+
+      private long executionTime_ ;
+      /**
+       * <pre>
+       *&#47; Holds the time taken for executing the whole suite.
+       * </pre>
+       *
+       * <code>int64 executionTime = 2;</code>
+       */
+      public long getExecutionTime() {
+        return executionTime_;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the time taken for executing the whole suite.
+       * </pre>
+       *
+       * <code>int64 executionTime = 2;</code>
+       */
+      public Builder setExecutionTime(long value) {
+        
+        executionTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the time taken for executing the whole suite.
+       * </pre>
+       *
+       * <code>int64 executionTime = 2;</code>
+       */
+      public Builder clearExecutionTime() {
+        
+        executionTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object timestamp_ = "";
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public java.lang.String getTimestamp() {
+        java.lang.Object ref = timestamp_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          timestamp_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTimestampBytes() {
+        java.lang.Object ref = timestamp_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          timestamp_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public Builder setTimestamp(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        timestamp_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public Builder clearTimestamp() {
+        
+        timestamp_ = getDefaultInstance().getTimestamp();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *&#47; Holds the timestamp of event starting.
+       * </pre>
+       *
+       * <code>string timestamp = 3;</code>
+       */
+      public Builder setTimestampBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        timestamp_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:gauge.messages.ProtoStepResult)
+    }
+
+    // @@protoc_insertion_point(class_scope:gauge.messages.ProtoStepResult)
+    private static final gauge.messages.Spec.ProtoStepResult DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new gauge.messages.Spec.ProtoStepResult();
+    }
+
+    public static gauge.messages.Spec.ProtoStepResult getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ProtoStepResult>
+        PARSER = new com.google.protobuf.AbstractParser<ProtoStepResult>() {
+      @java.lang.Override
+      public ProtoStepResult parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ProtoStepResult(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ProtoStepResult> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ProtoStepResult> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public gauge.messages.Spec.ProtoStepResult getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -35324,6 +41209,16 @@ public final class Spec {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_gauge_messages_ProtoSpecResult_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gauge_messages_ProtoScenarioResult_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_gauge_messages_ProtoScenarioResult_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gauge_messages_ProtoStepResult_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_gauge_messages_ProtoStepResult_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_gauge_messages_Error_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -35342,7 +41237,7 @@ public final class Spec {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\nspec.proto\022\016gauge.messages\"\235\003\n\tProtoSp" +
+      "\n\nspec.proto\022\016gauge.messages\"\371\003\n\tProtoSp" +
       "ec\022\023\n\013specHeading\030\001 \001(\t\022(\n\005items\030\002 \003(\0132\031" +
       ".gauge.messages.ProtoItem\022\025\n\risTableDriv" +
       "en\030\003 \001(\010\0229\n\017preHookFailures\030\004 \003(\0132 .gaug" +
@@ -35351,117 +41246,140 @@ public final class Spec {
       "Failure\022\020\n\010fileName\030\006 \001(\t\022\014\n\004tags\030\007 \003(\t\022" +
       "\027\n\017preHookMessages\030\010 \003(\t\022\030\n\020postHookMess" +
       "ages\030\t \003(\t\022\032\n\016preHookMessage\030\n \003(\tB\002\030\001\022\033" +
-      "\n\017postHookMessage\030\013 \003(\tB\002\030\001\022\032\n\022preHookSc" +
-      "reenshots\030\014 \003(\014\022\033\n\023postHookScreenshots\030\r" +
-      " \003(\014\"\200\004\n\tProtoItem\0224\n\010itemType\030\001 \001(\0162\".g" +
-      "auge.messages.ProtoItem.ItemType\022\'\n\004step" +
-      "\030\002 \001(\0132\031.gauge.messages.ProtoStep\022-\n\007con" +
-      "cept\030\003 \001(\0132\034.gauge.messages.ProtoConcept" +
-      "\022/\n\010scenario\030\004 \001(\0132\035.gauge.messages.Prot" +
-      "oScenario\022E\n\023tableDrivenScenario\030\005 \001(\0132(" +
-      ".gauge.messages.ProtoTableDrivenScenario" +
-      "\022-\n\007comment\030\006 \001(\0132\034.gauge.messages.Proto" +
-      "Comment\022)\n\005table\030\007 \001(\0132\032.gauge.messages." +
-      "ProtoTable\022\'\n\004tags\030\010 \001(\0132\031.gauge.message" +
-      "s.ProtoTags\"j\n\010ItemType\022\010\n\004Step\020\000\022\013\n\007Com" +
-      "ment\020\001\022\013\n\007Concept\020\002\022\014\n\010Scenario\020\003\022\027\n\023Tab" +
-      "leDrivenScenario\020\004\022\t\n\005Table\020\005\022\010\n\004Tags\020\006\"" +
-      "\237\005\n\rProtoScenario\022\027\n\017scenarioHeading\030\001 \001" +
-      "(\t\022\022\n\006failed\030\002 \001(\010B\002\030\001\022+\n\010contexts\030\003 \003(\013" +
-      "2\031.gauge.messages.ProtoItem\0220\n\rscenarioI" +
-      "tems\030\004 \003(\0132\031.gauge.messages.ProtoItem\0228\n" +
-      "\016preHookFailure\030\005 \001(\0132 .gauge.messages.P" +
-      "rotoHookFailure\0229\n\017postHookFailure\030\006 \001(\013" +
-      "2 .gauge.messages.ProtoHookFailure\022\014\n\004ta" +
-      "gs\030\007 \003(\t\022\025\n\rexecutionTime\030\010 \001(\003\022\023\n\007skipp" +
-      "ed\030\t \001(\010B\002\030\001\022\022\n\nskipErrors\030\n \003(\t\022\n\n\002ID\030\013" +
-      " \001(\t\0220\n\rtearDownSteps\030\014 \003(\0132\031.gauge.mess" +
-      "ages.ProtoItem\022\"\n\004span\030\r \001(\0132\024.gauge.mes" +
-      "sages.Span\0228\n\017executionStatus\030\016 \001(\0162\037.ga" +
-      "uge.messages.ExecutionStatus\022\027\n\017preHookM" +
-      "essages\030\017 \003(\t\022\030\n\020postHookMessages\030\020 \003(\t\022" +
-      "\032\n\016preHookMessage\030\021 \003(\tB\002\030\001\022\033\n\017postHookM" +
-      "essage\030\022 \003(\tB\002\030\001\022\032\n\022preHookScreenshots\030\023" +
-      " \003(\014\022\033\n\023postHookScreenshots\030\024 \003(\014\"F\n\004Spa" +
-      "n\022\r\n\005start\030\001 \001(\003\022\013\n\003end\030\002 \001(\003\022\021\n\tstartCh" +
-      "ar\030\003 \001(\003\022\017\n\007endChar\030\004 \001(\003\"b\n\030ProtoTableD" +
-      "rivenScenario\022/\n\010scenario\030\001 \001(\0132\035.gauge." +
-      "messages.ProtoScenario\022\025\n\rtableRowIndex\030" +
-      "\002 \001(\005\"\223\002\n\tProtoStep\022\022\n\nactualText\030\001 \001(\t\022" +
-      "\022\n\nparsedText\030\002 \001(\t\022+\n\tfragments\030\003 \003(\0132\030" +
-      ".gauge.messages.Fragment\022E\n\023stepExecutio" +
-      "nResult\030\004 \001(\0132(.gauge.messages.ProtoStep" +
-      "ExecutionResult\022\027\n\017preHookMessages\030\005 \003(\t" +
-      "\022\030\n\020postHookMessages\030\006 \003(\t\022\032\n\022preHookScr" +
-      "eenshots\030\007 \003(\014\022\033\n\023postHookScreenshots\030\010 " +
-      "\003(\014\"\262\001\n\014ProtoConcept\022.\n\013conceptStep\030\001 \001(" +
-      "\0132\031.gauge.messages.ProtoStep\022(\n\005steps\030\002 " +
-      "\003(\0132\031.gauge.messages.ProtoItem\022H\n\026concep" +
-      "tExecutionResult\030\003 \001(\0132(.gauge.messages." +
-      "ProtoStepExecutionResult\"\031\n\tProtoTags\022\014\n" +
-      "\004tags\030\001 \003(\t\"\254\001\n\010Fragment\022;\n\014fragmentType" +
-      "\030\001 \001(\0162%.gauge.messages.Fragment.Fragmen" +
-      "tType\022\014\n\004text\030\002 \001(\t\022,\n\tparameter\030\003 \001(\0132\031" +
-      ".gauge.messages.Parameter\"\'\n\014FragmentTyp" +
-      "e\022\010\n\004Text\020\000\022\r\n\tParameter\020\001\"\357\001\n\tParameter" +
-      "\022>\n\rparameterType\030\001 \001(\0162\'.gauge.messages" +
-      ".Parameter.ParameterType\022\r\n\005value\030\002 \001(\t\022" +
-      "\014\n\004name\030\003 \001(\t\022)\n\005table\030\004 \001(\0132\032.gauge.mes" +
-      "sages.ProtoTable\"Z\n\rParameterType\022\n\n\006Sta" +
-      "tic\020\000\022\013\n\007Dynamic\020\001\022\022\n\016Special_String\020\002\022\021" +
-      "\n\rSpecial_Table\020\003\022\t\n\005Table\020\004\"\034\n\014ProtoCom" +
-      "ment\022\014\n\004text\030\001 \001(\t\"i\n\nProtoTable\022.\n\007head" +
-      "ers\030\001 \001(\0132\035.gauge.messages.ProtoTableRow" +
-      "\022+\n\004rows\030\002 \003(\0132\035.gauge.messages.ProtoTab" +
-      "leRow\"\036\n\rProtoTableRow\022\r\n\005cells\030\001 \003(\t\"\366\001" +
-      "\n\030ProtoStepExecutionResult\022=\n\017executionR" +
-      "esult\030\001 \001(\0132$.gauge.messages.ProtoExecut" +
-      "ionResult\0228\n\016preHookFailure\030\002 \001(\0132 .gaug" +
-      "e.messages.ProtoHookFailure\0229\n\017postHookF" +
-      "ailure\030\003 \001(\0132 .gauge.messages.ProtoHookF" +
-      "ailure\022\017\n\007skipped\030\004 \001(\010\022\025\n\rskippedReason" +
-      "\030\005 \001(\t\"\313\002\n\024ProtoExecutionResult\022\016\n\006faile" +
-      "d\030\001 \001(\010\022\030\n\020recoverableError\030\002 \001(\010\022\024\n\014err" +
-      "orMessage\030\003 \001(\t\022\022\n\nstackTrace\030\004 \001(\t\022\026\n\ns" +
-      "creenShot\030\005 \001(\014B\002\030\001\022\025\n\rexecutionTime\030\006 \001" +
-      "(\003\022\017\n\007message\030\007 \003(\t\022A\n\terrorType\030\010 \001(\0162." +
-      ".gauge.messages.ProtoExecutionResult.Err" +
-      "orType\022\031\n\021failureScreenshot\030\t \001(\014\022\023\n\013scr" +
-      "eenshots\030\n \003(\014\",\n\tErrorType\022\r\n\tASSERTION" +
-      "\020\000\022\020\n\014VERIFICATION\020\001\"\206\001\n\020ProtoHookFailur" +
-      "e\022\022\n\nstackTrace\030\001 \001(\t\022\024\n\014errorMessage\030\002 " +
-      "\001(\t\022\026\n\nscreenShot\030\003 \001(\014B\002\030\001\022\025\n\rtableRowI" +
-      "ndex\030\004 \001(\005\022\031\n\021failureScreenshot\030\005 \001(\014\"\236\004" +
-      "\n\020ProtoSuiteResult\0224\n\013specResults\030\001 \003(\0132" +
-      "\037.gauge.messages.ProtoSpecResult\0228\n\016preH" +
-      "ookFailure\030\002 \001(\0132 .gauge.messages.ProtoH" +
-      "ookFailure\0229\n\017postHookFailure\030\003 \001(\0132 .ga" +
-      "uge.messages.ProtoHookFailure\022\016\n\006failed\030" +
-      "\004 \001(\010\022\030\n\020specsFailedCount\030\005 \001(\005\022\025\n\rexecu" +
-      "tionTime\030\006 \001(\003\022\023\n\013successRate\030\007 \001(\002\022\023\n\013e" +
-      "nvironment\030\010 \001(\t\022\014\n\004tags\030\t \001(\t\022\023\n\013projec" +
-      "tName\030\n \001(\t\022\021\n\ttimestamp\030\013 \001(\t\022\031\n\021specsS" +
-      "kippedCount\030\014 \001(\005\022\027\n\017preHookMessages\030\r \003" +
-      "(\t\022\030\n\020postHookMessages\030\016 \003(\t\022\032\n\016preHookM" +
-      "essage\030\017 \003(\tB\002\030\001\022\033\n\017postHookMessage\030\020 \003(" +
-      "\tB\002\030\001\022\032\n\022preHookScreenshots\030\021 \003(\014\022\033\n\023pos" +
-      "tHookScreenshots\030\022 \003(\014\"\253\002\n\017ProtoSpecResu" +
-      "lt\022,\n\tprotoSpec\030\001 \001(\0132\031.gauge.messages.P" +
-      "rotoSpec\022\025\n\rscenarioCount\030\002 \001(\005\022\033\n\023scena" +
-      "rioFailedCount\030\003 \001(\005\022\016\n\006failed\030\004 \001(\010\022\033\n\023" +
-      "failedDataTableRows\030\005 \003(\005\022\025\n\rexecutionTi" +
-      "me\030\006 \001(\003\022\017\n\007skipped\030\007 \001(\010\022\034\n\024scenarioSki" +
-      "ppedCount\030\010 \001(\005\022\034\n\024skippedDataTableRows\030" +
-      "\t \003(\005\022%\n\006errors\030\n \003(\0132\025.gauge.messages.E" +
-      "rror\"\241\001\n\005Error\022-\n\004type\030\001 \001(\0162\037.gauge.mes" +
-      "sages.Error.ErrorType\022\020\n\010filename\030\002 \001(\t\022" +
-      "\022\n\nlineNumber\030\003 \001(\005\022\017\n\007message\030\004 \001(\t\"2\n\t" +
-      "ErrorType\022\017\n\013PARSE_ERROR\020\000\022\024\n\020VALIDATION" +
-      "_ERROR\020\001\"W\n\016ProtoStepValue\022\021\n\tstepValue\030" +
-      "\001 \001(\t\022\036\n\026parameterizedStepValue\030\002 \001(\t\022\022\n" +
-      "\nparameters\030\003 \003(\t*G\n\017ExecutionStatus\022\017\n\013" +
-      "NOTEXECUTED\020\000\022\n\n\006PASSED\020\001\022\n\n\006FAILED\020\002\022\013\n" +
-      "\007SKIPPED\020\003B\021\252\002\016Gauge.Messagesb\006proto3"
+      "\n\017postHookMessage\030\013 \003(\tB\002\030\001\022\036\n\022preHookSc" +
+      "reenshots\030\014 \003(\014B\002\030\001\022\037\n\023postHookScreensho" +
+      "ts\030\r \003(\014B\002\030\001\022\021\n\titemCount\030\016 \001(\003\022\036\n\026preHo" +
+      "okScreenshotFiles\030\017 \003(\t\022\037\n\027postHookScree" +
+      "nshotFiles\030\020 \003(\t\"\222\004\n\tProtoItem\0224\n\010itemTy" +
+      "pe\030\001 \001(\0162\".gauge.messages.ProtoItem.Item" +
+      "Type\022\'\n\004step\030\002 \001(\0132\031.gauge.messages.Prot" +
+      "oStep\022-\n\007concept\030\003 \001(\0132\034.gauge.messages." +
+      "ProtoConcept\022/\n\010scenario\030\004 \001(\0132\035.gauge.m" +
+      "essages.ProtoScenario\022E\n\023tableDrivenScen" +
+      "ario\030\005 \001(\0132(.gauge.messages.ProtoTableDr" +
+      "ivenScenario\022-\n\007comment\030\006 \001(\0132\034.gauge.me" +
+      "ssages.ProtoComment\022)\n\005table\030\007 \001(\0132\032.gau" +
+      "ge.messages.ProtoTable\022\'\n\004tags\030\010 \001(\0132\031.g" +
+      "auge.messages.ProtoTags\022\020\n\010fileName\030\t \001(" +
+      "\t\"j\n\010ItemType\022\010\n\004Step\020\000\022\013\n\007Comment\020\001\022\013\n\007" +
+      "Concept\020\002\022\014\n\010Scenario\020\003\022\027\n\023TableDrivenSc" +
+      "enario\020\004\022\t\n\005Table\020\005\022\010\n\004Tags\020\006\"\350\005\n\rProtoS" +
+      "cenario\022\027\n\017scenarioHeading\030\001 \001(\t\022\022\n\006fail" +
+      "ed\030\002 \001(\010B\002\030\001\022+\n\010contexts\030\003 \003(\0132\031.gauge.m" +
+      "essages.ProtoItem\0220\n\rscenarioItems\030\004 \003(\013" +
+      "2\031.gauge.messages.ProtoItem\0228\n\016preHookFa" +
+      "ilure\030\005 \001(\0132 .gauge.messages.ProtoHookFa" +
+      "ilure\0229\n\017postHookFailure\030\006 \001(\0132 .gauge.m" +
+      "essages.ProtoHookFailure\022\014\n\004tags\030\007 \003(\t\022\025" +
+      "\n\rexecutionTime\030\010 \001(\003\022\023\n\007skipped\030\t \001(\010B\002" +
+      "\030\001\022\022\n\nskipErrors\030\n \003(\t\022\n\n\002ID\030\013 \001(\t\0220\n\rte" +
+      "arDownSteps\030\014 \003(\0132\031.gauge.messages.Proto" +
+      "Item\022\"\n\004span\030\r \001(\0132\024.gauge.messages.Span" +
+      "\0228\n\017executionStatus\030\016 \001(\0162\037.gauge.messag" +
+      "es.ExecutionStatus\022\027\n\017preHookMessages\030\017 " +
+      "\003(\t\022\030\n\020postHookMessages\030\020 \003(\t\022\032\n\016preHook" +
+      "Message\030\021 \003(\tB\002\030\001\022\033\n\017postHookMessage\030\022 \003" +
+      "(\tB\002\030\001\022\036\n\022preHookScreenshots\030\023 \003(\014B\002\030\001\022\037" +
+      "\n\023postHookScreenshots\030\024 \003(\014B\002\030\001\022\036\n\026preHo" +
+      "okScreenshotFiles\030\025 \003(\t\022\037\n\027postHookScree" +
+      "nshotFiles\030\026 \003(\t\"F\n\004Span\022\r\n\005start\030\001 \001(\003\022" +
+      "\013\n\003end\030\002 \001(\003\022\021\n\tstartChar\030\003 \001(\003\022\017\n\007endCh" +
+      "ar\030\004 \001(\003\"\250\002\n\030ProtoTableDrivenScenario\022/\n" +
+      "\010scenario\030\001 \001(\0132\035.gauge.messages.ProtoSc" +
+      "enario\022\025\n\rtableRowIndex\030\002 \001(\005\022\035\n\025scenari" +
+      "oTableRowIndex\030\003 \001(\005\022\031\n\021isSpecTableDrive" +
+      "n\030\004 \001(\010\022\035\n\025isScenarioTableDriven\030\005 \001(\010\0225" +
+      "\n\021scenarioDataTable\030\006 \001(\0132\032.gauge.messag" +
+      "es.ProtoTable\0224\n\020scenarioTableRow\030\007 \001(\0132" +
+      "\032.gauge.messages.ProtoTable\"\334\002\n\tProtoSte" +
+      "p\022\022\n\nactualText\030\001 \001(\t\022\022\n\nparsedText\030\002 \001(" +
+      "\t\022+\n\tfragments\030\003 \003(\0132\030.gauge.messages.Fr" +
+      "agment\022E\n\023stepExecutionResult\030\004 \001(\0132(.ga" +
+      "uge.messages.ProtoStepExecutionResult\022\027\n" +
+      "\017preHookMessages\030\005 \003(\t\022\030\n\020postHookMessag" +
+      "es\030\006 \003(\t\022\036\n\022preHookScreenshots\030\007 \003(\014B\002\030\001" +
+      "\022\037\n\023postHookScreenshots\030\010 \003(\014B\002\030\001\022\036\n\026pre" +
+      "HookScreenshotFiles\030\t \003(\t\022\037\n\027postHookScr" +
+      "eenshotFiles\030\n \003(\t\"\262\001\n\014ProtoConcept\022.\n\013c" +
+      "onceptStep\030\001 \001(\0132\031.gauge.messages.ProtoS" +
+      "tep\022(\n\005steps\030\002 \003(\0132\031.gauge.messages.Prot" +
+      "oItem\022H\n\026conceptExecutionResult\030\003 \001(\0132(." +
+      "gauge.messages.ProtoStepExecutionResult\"" +
+      "\031\n\tProtoTags\022\014\n\004tags\030\001 \003(\t\"\254\001\n\010Fragment\022" +
+      ";\n\014fragmentType\030\001 \001(\0162%.gauge.messages.F" +
+      "ragment.FragmentType\022\014\n\004text\030\002 \001(\t\022,\n\tpa" +
+      "rameter\030\003 \001(\0132\031.gauge.messages.Parameter" +
+      "\"\'\n\014FragmentType\022\010\n\004Text\020\000\022\r\n\tParameter\020" +
+      "\001\"\357\001\n\tParameter\022>\n\rparameterType\030\001 \001(\0162\'" +
+      ".gauge.messages.Parameter.ParameterType\022" +
+      "\r\n\005value\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022)\n\005table\030\004 " +
+      "\001(\0132\032.gauge.messages.ProtoTable\"Z\n\rParam" +
+      "eterType\022\n\n\006Static\020\000\022\013\n\007Dynamic\020\001\022\022\n\016Spe" +
+      "cial_String\020\002\022\021\n\rSpecial_Table\020\003\022\t\n\005Tabl" +
+      "e\020\004\"\034\n\014ProtoComment\022\014\n\004text\030\001 \001(\t\"i\n\nPro" +
+      "toTable\022.\n\007headers\030\001 \001(\0132\035.gauge.message" +
+      "s.ProtoTableRow\022+\n\004rows\030\002 \003(\0132\035.gauge.me" +
+      "ssages.ProtoTableRow\"\036\n\rProtoTableRow\022\r\n" +
+      "\005cells\030\001 \003(\t\"\366\001\n\030ProtoStepExecutionResul" +
+      "t\022=\n\017executionResult\030\001 \001(\0132$.gauge.messa" +
+      "ges.ProtoExecutionResult\0228\n\016preHookFailu" +
+      "re\030\002 \001(\0132 .gauge.messages.ProtoHookFailu" +
+      "re\0229\n\017postHookFailure\030\003 \001(\0132 .gauge.mess" +
+      "ages.ProtoHookFailure\022\017\n\007skipped\030\004 \001(\010\022\025" +
+      "\n\rskippedReason\030\005 \001(\t\"\213\003\n\024ProtoExecution" +
+      "Result\022\016\n\006failed\030\001 \001(\010\022\030\n\020recoverableErr" +
+      "or\030\002 \001(\010\022\024\n\014errorMessage\030\003 \001(\t\022\022\n\nstackT" +
+      "race\030\004 \001(\t\022\026\n\nscreenShot\030\005 \001(\014B\002\030\001\022\025\n\rex" +
+      "ecutionTime\030\006 \001(\003\022\017\n\007message\030\007 \003(\t\022A\n\ter" +
+      "rorType\030\010 \001(\0162..gauge.messages.ProtoExec" +
+      "utionResult.ErrorType\022\035\n\021failureScreensh" +
+      "ot\030\t \001(\014B\002\030\001\022\027\n\013screenshots\030\n \003(\014B\002\030\001\022\035\n" +
+      "\025failureScreenshotFile\030\013 \001(\t\022\027\n\017screensh" +
+      "otFiles\030\014 \003(\t\",\n\tErrorType\022\r\n\tASSERTION\020" +
+      "\000\022\020\n\014VERIFICATION\020\001\"\251\001\n\020ProtoHookFailure" +
+      "\022\022\n\nstackTrace\030\001 \001(\t\022\024\n\014errorMessage\030\002 \001" +
+      "(\t\022\026\n\nscreenShot\030\003 \001(\014B\002\030\001\022\025\n\rtableRowIn" +
+      "dex\030\004 \001(\005\022\035\n\021failureScreenshot\030\005 \001(\014B\002\030\001" +
+      "\022\035\n\025failureScreenshotFile\030\006 \001(\t\"\213\005\n\020Prot" +
+      "oSuiteResult\0224\n\013specResults\030\001 \003(\0132\037.gaug" +
+      "e.messages.ProtoSpecResult\0228\n\016preHookFai" +
+      "lure\030\002 \001(\0132 .gauge.messages.ProtoHookFai" +
+      "lure\0229\n\017postHookFailure\030\003 \001(\0132 .gauge.me" +
+      "ssages.ProtoHookFailure\022\016\n\006failed\030\004 \001(\010\022" +
+      "\030\n\020specsFailedCount\030\005 \001(\005\022\025\n\rexecutionTi" +
+      "me\030\006 \001(\003\022\023\n\013successRate\030\007 \001(\002\022\023\n\013environ" +
+      "ment\030\010 \001(\t\022\014\n\004tags\030\t \001(\t\022\023\n\013projectName\030" +
+      "\n \001(\t\022\021\n\ttimestamp\030\013 \001(\t\022\031\n\021specsSkipped" +
+      "Count\030\014 \001(\005\022\027\n\017preHookMessages\030\r \003(\t\022\030\n\020" +
+      "postHookMessages\030\016 \003(\t\022\032\n\016preHookMessage" +
+      "\030\017 \003(\tB\002\030\001\022\033\n\017postHookMessage\030\020 \003(\tB\002\030\001\022" +
+      "\036\n\022preHookScreenshots\030\021 \003(\014B\002\030\001\022\037\n\023postH" +
+      "ookScreenshots\030\022 \003(\014B\002\030\001\022\017\n\007chunked\030\023 \001(" +
+      "\010\022\021\n\tchunkSize\030\024 \001(\003\022\036\n\026preHookScreensho" +
+      "tFiles\030\025 \003(\t\022\037\n\027postHookScreenshotFiles\030" +
+      "\026 \003(\t\"\276\002\n\017ProtoSpecResult\022,\n\tprotoSpec\030\001" +
+      " \001(\0132\031.gauge.messages.ProtoSpec\022\025\n\rscena" +
+      "rioCount\030\002 \001(\005\022\033\n\023scenarioFailedCount\030\003 " +
+      "\001(\005\022\016\n\006failed\030\004 \001(\010\022\033\n\023failedDataTableRo" +
+      "ws\030\005 \003(\005\022\025\n\rexecutionTime\030\006 \001(\003\022\017\n\007skipp" +
+      "ed\030\007 \001(\010\022\034\n\024scenarioSkippedCount\030\010 \001(\005\022\034" +
+      "\n\024skippedDataTableRows\030\t \003(\005\022%\n\006errors\030\n" +
+      " \003(\0132\025.gauge.messages.Error\022\021\n\ttimestamp" +
+      "\030\013 \001(\t\"m\n\023ProtoScenarioResult\022,\n\tprotoIt" +
+      "em\030\001 \001(\0132\031.gauge.messages.ProtoItem\022\025\n\re" +
+      "xecutionTime\030\002 \001(\003\022\021\n\ttimestamp\030\003 \001(\t\"i\n" +
+      "\017ProtoStepResult\022,\n\tprotoItem\030\001 \001(\0132\031.ga" +
+      "uge.messages.ProtoItem\022\025\n\rexecutionTime\030" +
+      "\002 \001(\003\022\021\n\ttimestamp\030\003 \001(\t\"\241\001\n\005Error\022-\n\004ty" +
+      "pe\030\001 \001(\0162\037.gauge.messages.Error.ErrorTyp" +
+      "e\022\020\n\010filename\030\002 \001(\t\022\022\n\nlineNumber\030\003 \001(\005\022" +
+      "\017\n\007message\030\004 \001(\t\"2\n\tErrorType\022\017\n\013PARSE_E" +
+      "RROR\020\000\022\024\n\020VALIDATION_ERROR\020\001\"W\n\016ProtoSte" +
+      "pValue\022\021\n\tstepValue\030\001 \001(\t\022\036\n\026parameteriz" +
+      "edStepValue\030\002 \001(\t\022\022\n\nparameters\030\003 \003(\t*G\n" +
+      "\017ExecutionStatus\022\017\n\013NOTEXECUTED\020\000\022\n\n\006PAS" +
+      "SED\020\001\022\n\n\006FAILED\020\002\022\013\n\007SKIPPED\020\003B!\n\016gauge." +
+      "messages\252\002\016Gauge.Messagesb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -35480,19 +41398,19 @@ public final class Spec {
     internal_static_gauge_messages_ProtoSpec_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoSpec_descriptor,
-        new java.lang.String[] { "SpecHeading", "Items", "IsTableDriven", "PreHookFailures", "PostHookFailures", "FileName", "Tags", "PreHookMessages", "PostHookMessages", "PreHookMessage", "PostHookMessage", "PreHookScreenshots", "PostHookScreenshots", });
+        new java.lang.String[] { "SpecHeading", "Items", "IsTableDriven", "PreHookFailures", "PostHookFailures", "FileName", "Tags", "PreHookMessages", "PostHookMessages", "PreHookMessage", "PostHookMessage", "PreHookScreenshots", "PostHookScreenshots", "ItemCount", "PreHookScreenshotFiles", "PostHookScreenshotFiles", });
     internal_static_gauge_messages_ProtoItem_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_gauge_messages_ProtoItem_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoItem_descriptor,
-        new java.lang.String[] { "ItemType", "Step", "Concept", "Scenario", "TableDrivenScenario", "Comment", "Table", "Tags", });
+        new java.lang.String[] { "ItemType", "Step", "Concept", "Scenario", "TableDrivenScenario", "Comment", "Table", "Tags", "FileName", });
     internal_static_gauge_messages_ProtoScenario_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_gauge_messages_ProtoScenario_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoScenario_descriptor,
-        new java.lang.String[] { "ScenarioHeading", "Failed", "Contexts", "ScenarioItems", "PreHookFailure", "PostHookFailure", "Tags", "ExecutionTime", "Skipped", "SkipErrors", "ID", "TearDownSteps", "Span", "ExecutionStatus", "PreHookMessages", "PostHookMessages", "PreHookMessage", "PostHookMessage", "PreHookScreenshots", "PostHookScreenshots", });
+        new java.lang.String[] { "ScenarioHeading", "Failed", "Contexts", "ScenarioItems", "PreHookFailure", "PostHookFailure", "Tags", "ExecutionTime", "Skipped", "SkipErrors", "ID", "TearDownSteps", "Span", "ExecutionStatus", "PreHookMessages", "PostHookMessages", "PreHookMessage", "PostHookMessage", "PreHookScreenshots", "PostHookScreenshots", "PreHookScreenshotFiles", "PostHookScreenshotFiles", });
     internal_static_gauge_messages_Span_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_gauge_messages_Span_fieldAccessorTable = new
@@ -35504,13 +41422,13 @@ public final class Spec {
     internal_static_gauge_messages_ProtoTableDrivenScenario_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoTableDrivenScenario_descriptor,
-        new java.lang.String[] { "Scenario", "TableRowIndex", });
+        new java.lang.String[] { "Scenario", "TableRowIndex", "ScenarioTableRowIndex", "IsSpecTableDriven", "IsScenarioTableDriven", "ScenarioDataTable", "ScenarioTableRow", });
     internal_static_gauge_messages_ProtoStep_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_gauge_messages_ProtoStep_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoStep_descriptor,
-        new java.lang.String[] { "ActualText", "ParsedText", "Fragments", "StepExecutionResult", "PreHookMessages", "PostHookMessages", "PreHookScreenshots", "PostHookScreenshots", });
+        new java.lang.String[] { "ActualText", "ParsedText", "Fragments", "StepExecutionResult", "PreHookMessages", "PostHookMessages", "PreHookScreenshots", "PostHookScreenshots", "PreHookScreenshotFiles", "PostHookScreenshotFiles", });
     internal_static_gauge_messages_ProtoConcept_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_gauge_messages_ProtoConcept_fieldAccessorTable = new
@@ -35564,33 +41482,45 @@ public final class Spec {
     internal_static_gauge_messages_ProtoExecutionResult_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoExecutionResult_descriptor,
-        new java.lang.String[] { "Failed", "RecoverableError", "ErrorMessage", "StackTrace", "ScreenShot", "ExecutionTime", "Message", "ErrorType", "FailureScreenshot", "Screenshots", });
+        new java.lang.String[] { "Failed", "RecoverableError", "ErrorMessage", "StackTrace", "ScreenShot", "ExecutionTime", "Message", "ErrorType", "FailureScreenshot", "Screenshots", "FailureScreenshotFile", "ScreenshotFiles", });
     internal_static_gauge_messages_ProtoHookFailure_descriptor =
       getDescriptor().getMessageTypes().get(15);
     internal_static_gauge_messages_ProtoHookFailure_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoHookFailure_descriptor,
-        new java.lang.String[] { "StackTrace", "ErrorMessage", "ScreenShot", "TableRowIndex", "FailureScreenshot", });
+        new java.lang.String[] { "StackTrace", "ErrorMessage", "ScreenShot", "TableRowIndex", "FailureScreenshot", "FailureScreenshotFile", });
     internal_static_gauge_messages_ProtoSuiteResult_descriptor =
       getDescriptor().getMessageTypes().get(16);
     internal_static_gauge_messages_ProtoSuiteResult_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoSuiteResult_descriptor,
-        new java.lang.String[] { "SpecResults", "PreHookFailure", "PostHookFailure", "Failed", "SpecsFailedCount", "ExecutionTime", "SuccessRate", "Environment", "Tags", "ProjectName", "Timestamp", "SpecsSkippedCount", "PreHookMessages", "PostHookMessages", "PreHookMessage", "PostHookMessage", "PreHookScreenshots", "PostHookScreenshots", });
+        new java.lang.String[] { "SpecResults", "PreHookFailure", "PostHookFailure", "Failed", "SpecsFailedCount", "ExecutionTime", "SuccessRate", "Environment", "Tags", "ProjectName", "Timestamp", "SpecsSkippedCount", "PreHookMessages", "PostHookMessages", "PreHookMessage", "PostHookMessage", "PreHookScreenshots", "PostHookScreenshots", "Chunked", "ChunkSize", "PreHookScreenshotFiles", "PostHookScreenshotFiles", });
     internal_static_gauge_messages_ProtoSpecResult_descriptor =
       getDescriptor().getMessageTypes().get(17);
     internal_static_gauge_messages_ProtoSpecResult_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoSpecResult_descriptor,
-        new java.lang.String[] { "ProtoSpec", "ScenarioCount", "ScenarioFailedCount", "Failed", "FailedDataTableRows", "ExecutionTime", "Skipped", "ScenarioSkippedCount", "SkippedDataTableRows", "Errors", });
-    internal_static_gauge_messages_Error_descriptor =
+        new java.lang.String[] { "ProtoSpec", "ScenarioCount", "ScenarioFailedCount", "Failed", "FailedDataTableRows", "ExecutionTime", "Skipped", "ScenarioSkippedCount", "SkippedDataTableRows", "Errors", "Timestamp", });
+    internal_static_gauge_messages_ProtoScenarioResult_descriptor =
       getDescriptor().getMessageTypes().get(18);
+    internal_static_gauge_messages_ProtoScenarioResult_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_gauge_messages_ProtoScenarioResult_descriptor,
+        new java.lang.String[] { "ProtoItem", "ExecutionTime", "Timestamp", });
+    internal_static_gauge_messages_ProtoStepResult_descriptor =
+      getDescriptor().getMessageTypes().get(19);
+    internal_static_gauge_messages_ProtoStepResult_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_gauge_messages_ProtoStepResult_descriptor,
+        new java.lang.String[] { "ProtoItem", "ExecutionTime", "Timestamp", });
+    internal_static_gauge_messages_Error_descriptor =
+      getDescriptor().getMessageTypes().get(20);
     internal_static_gauge_messages_Error_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_Error_descriptor,
         new java.lang.String[] { "Type", "Filename", "LineNumber", "Message", });
     internal_static_gauge_messages_ProtoStepValue_descriptor =
-      getDescriptor().getMessageTypes().get(19);
+      getDescriptor().getMessageTypes().get(21);
     internal_static_gauge_messages_ProtoStepValue_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_gauge_messages_ProtoStepValue_descriptor,

--- a/src/test/java/com/thoughtworks/gauge/ScreenshotCollectorTest.java
+++ b/src/test/java/com/thoughtworks/gauge/ScreenshotCollectorTest.java
@@ -15,7 +15,6 @@
 
 package com.thoughtworks.gauge;
 
-import com.google.protobuf.ByteString;
 import gauge.messages.Spec;
 import junit.framework.TestCase;
 
@@ -25,15 +24,15 @@ import java.util.List;
 public class ScreenshotCollectorTest extends TestCase {
     public void testAddingScreenshotsToProtoResult() {
         Spec.ProtoExecutionResult executionResult = emptyExecResult();
-        byte a = Byte.valueOf("1");
-        byte b = Byte.valueOf("2");
-        byte[] bytes = {a,b};
-        List<byte[]> screenshots = new ArrayList<>();
-        screenshots.add(bytes);
+        String a = "1";
+        String b = "2";
+        List<String> screenshots = new ArrayList<>();
+        screenshots.add(a);
+        screenshots.add(b);
         Spec.ProtoExecutionResult protoExecutionResult = new ScreenshotCollector().addPendingScreenshot(executionResult, screenshots);
-        List<ByteString> actualScreenshotList = protoExecutionResult.getScreenshotsList();
-        for (byte[] screenshot : screenshots) {
-            assertTrue(actualScreenshotList.contains(ByteString.copyFrom(screenshot)));
+        List<String> actualScreenshotList = protoExecutionResult.getScreenshotFilesList();
+        for (String screenshot : screenshots) {
+            assertTrue(actualScreenshotList.contains(screenshot));
         }
     }
 

--- a/src/test/java/com/thoughtworks/gauge/execution/AbstractExecutionStageTest.java
+++ b/src/test/java/com/thoughtworks/gauge/execution/AbstractExecutionStageTest.java
@@ -15,7 +15,6 @@
 
 package com.thoughtworks.gauge.execution;
 
-import com.google.protobuf.ByteString;
 import gauge.messages.Spec;
 import junit.framework.TestCase;
 
@@ -30,17 +29,14 @@ public class AbstractExecutionStageTest extends TestCase {
     }
 
     public void testMergingResultsPreviousFailing() throws Exception {
-
-        Byte b = Byte.valueOf("1");
-        byte[] bytes = {b};
-        ByteString screenShot = ByteString.copyFrom(bytes);
+        String screenShot = "1";
 
         Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
                 setExecutionTime(100).
                 setRecoverableError(false).
                 setErrorMessage("Previous failed").
                 setStackTrace("Previous stacktrace").
-                setFailureScreenshot(screenShot).build();
+                setFailureScreenshotFile(screenShot).build();
         Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(1100).build();
         Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
@@ -49,13 +45,11 @@ public class AbstractExecutionStageTest extends TestCase {
         assertEquals("Previous failed", result.getErrorMessage());
         assertEquals("Previous stacktrace", result.getStackTrace());
         assertFalse(result.getRecoverableError());
-        assertEquals(screenShot, result.getFailureScreenshot());
+        assertEquals(screenShot, result.getFailureScreenshotFile());
     }
 
     public void testMergingResultsCurrentFailing() throws Exception {
-        Byte b = Byte.valueOf("2");
-        byte[] bytes = {b};
-        ByteString screenShot = ByteString.copyFrom(bytes);
+        String screenShot = "2";
 
         Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(100).build();
         Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
@@ -63,7 +57,7 @@ public class AbstractExecutionStageTest extends TestCase {
                 setRecoverableError(false).
                 setErrorMessage("current failed").
                 setStackTrace("current stacktrace").
-                setFailureScreenshot(screenShot).build();
+                setFailureScreenshotFile(screenShot).build();
         Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
         assertTrue(result.getFailed());
@@ -71,27 +65,25 @@ public class AbstractExecutionStageTest extends TestCase {
         assertEquals("current failed", result.getErrorMessage());
         assertEquals("current stacktrace", result.getStackTrace());
         assertFalse(result.getRecoverableError());
-        assertEquals(screenShot, result.getFailureScreenshot());
+        assertEquals(screenShot, result.getFailureScreenshotFile());
     }
 
     public void testMergingResultsBothFailing() throws Exception {
-        Byte b = Byte.valueOf("2");
-        byte[] bytes = {b};
-        ByteString screenShotPrevious = ByteString.copyFrom(bytes);
-        ByteString screenShotCurrent = ByteString.copyFromUtf8("hello");
+        String screenShotPrevious = "2";
+        String screenShotCurrent = "hello";
 
         Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
                 setExecutionTime(1001).
                 setRecoverableError(true).
                 setErrorMessage("previous failed").
                 setStackTrace("previous stacktrace").
-                setFailureScreenshot(screenShotPrevious).build();
+                setFailureScreenshotFile(screenShotPrevious).build();
         Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
                 setExecutionTime(1002).
                 setRecoverableError(false).
                 setErrorMessage("current failed").
                 setStackTrace("current stacktrace").
-                setFailureScreenshot(screenShotCurrent).build();
+                setFailureScreenshotFile(screenShotCurrent).build();
         Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
         assertTrue(result.getFailed());
@@ -99,11 +91,11 @@ public class AbstractExecutionStageTest extends TestCase {
         assertEquals("previous failed", result.getErrorMessage());
         assertEquals("previous stacktrace", result.getStackTrace());
         assertFalse(result.getRecoverableError());
-        assertEquals(screenShotPrevious, result.getFailureScreenshot());
+        assertEquals(screenShotPrevious, result.getFailureScreenshotFile());
     }
 
     public void testMergingResultsCurrentFailingAndIsRecoverable() throws Exception {
-        ByteString screenShotCurrent = ByteString.copyFromUtf8("hello");
+        String screenShotCurrent = "screenShotCurrent.png";
 
         Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(1001).build();
         Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
@@ -111,7 +103,7 @@ public class AbstractExecutionStageTest extends TestCase {
                 setRecoverableError(true).
                 setErrorMessage("current failed").
                 setStackTrace("current stacktrace").
-                setFailureScreenshot(screenShotCurrent).build();
+                setFailureScreenshotFile(screenShotCurrent).build();
         Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
         assertTrue(result.getFailed());
@@ -119,7 +111,7 @@ public class AbstractExecutionStageTest extends TestCase {
         assertEquals("current failed", result.getErrorMessage());
         assertEquals("current stacktrace", result.getStackTrace());
         assertTrue(result.getRecoverableError());
-        assertEquals(screenShotCurrent, result.getFailureScreenshot());
+        assertEquals(screenShotCurrent, result.getFailureScreenshotFile());
     }
 
     private class TestExecutionStage extends AbstractExecutionStage {


### PR DESCRIPTION
- [x] Changed default screenshot grabber to write to file and return file path.
- [x] Depricate existing custom screenshot grabber API contract.
- [x] Create a new API contact for custom screenshot grabber to write the screenshot into file and returning file path instead of screenhsot bytes.

```
import java.io.File;
import java.io.IOException;
import java.nio.file.Paths;
import org.apache.commons.io.FileUtils;
import org.openqa.selenium.OutputType;
import org.openqa.selenium.TakesScreenshot;
import com.thoughtworks.gauge.screenshot.CustomScreenshotWriter;

import driver.DriverFactory;

public class CustomScreenshotGrabber implements CustomScreenshotWriter {

    @Override
    public String takeScreenshot() {
        TakesScreenshot driver = (TakesScreenshot) DriverFactory.getDriver();
        File screenshotFile = new File(Paths.get(System.getenv("screenshots_dir"), "screenshot-1.png").toString());
        File tmpFile = driver.getScreenshotAs(OutputType.FILE);
        try {
            FileUtils.copyFile(tmpFile, screenshotFile);
        } catch (IOException e) {
            e.printStackTrace();
        }
        return screenshotFile.getName();
    }

}
```