### PR TITLE
Upgrade to version 2 of github actions checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         java_version: [ '1.8', '11.x.x', '12.x.x' ]
     steps:
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup java
         uses: actions/setup-java@v1
@@ -34,7 +34,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup java
         uses: actions/setup-java@v1
@@ -117,7 +117,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup go 1.13.1
         uses: actions/setup-go@v1


### PR DESCRIPTION
This change upgrades GitHub actions to v2 which solves a few problems with checking out the right revisions.