### PR TITLE
414 launcher fix

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "description": "Java support for gauge",
     "install": {
         "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <projectVersion>0.7.5</projectVersion>
+        <projectVersion>0.7.6</projectVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
- bumping version - 0.7.6
- fix version check of java, closes #414

### `gauge-java 0.7.5`

```
$ java -version
openjdk version "11.0.5" 2019-10-15
OpenJDK Runtime Environment (build 11.0.5+10-post-Ubuntu-0ubuntu1.1)
OpenJDK 64-Bit Server VM (build 11.0.5+10-post-Ubuntu-0ubuntu1.1, mixed mode, sharing)

$ gauge run specs
This version of gauge-java plugin does not support Java versions < 1.9
Please upgrade your Java version or use a version of gauge-java <= v0.7.4
Error occurred while waiting for runner process to finish.
Error : exit status 1
```

### post this fix

```
$ gauge run specs
# Specification Heading
  ## Vowel counts in single word         ✔ ✔
  ## Vowel counts in multiple word       ✔ ✔

Successfully generated html-report to => /tmp/foo/reports/html-report/index.html

Specifications: 1 executed      1 passed        0 failed        0 skipped
Scenarios:      2 executed      2 passed        0 failed        0 skipped

Total time taken: 1.82s
```



