### PR TITLE
Remove version 1.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java_version: [ '1.8', '11.x.x', '12.x.x' ]
+        java_version: [ '11', '12' ]
     steps:
 
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: '12.x.x'
+          java-version: '12'
 
       - uses: bugdiver/setup-gauge@master
         with:
@@ -107,7 +107,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: '12.x.x'
+          java-version: '12'
 
       - uses: bugdiver/setup-gauge@master
         with:


### PR DESCRIPTION
gauge-java does not support version 1.8 anymore

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>