### PR TITLE
Avoid doing plugin version validation in lsp mode.

### DIFF
--- a/bin/launcher.ps1
+++ b/bin/launcher.ps1
@@ -49,6 +49,9 @@ function ValidatePluginsVersion() {
     $BuildToolName,
     $BuildFileName
   )
+  if ( $env:GAUGE_LSP_GRPC -match "true") {
+      return
+  }
   $installed_gauge_java_version=((gauge -v -m | ConvertFrom-Json).plugins | Where-Object { $_.name -eq "java" }).version
   if ( $BuildToolName -match "maven" ) {
       $pom_data=mvn help:effective-pom

--- a/bin/launcher.sh
+++ b/bin/launcher.sh
@@ -145,6 +145,9 @@ extract_gauge_java_version() {
 }
 
 validate_plugins_version() {
+    if [ "$GAUGE_LSP_GRPC" = "true" ]; then
+        return
+    fi
     installed_gauge_java=$(getInstalledGaugeJavaVersion)
     if [ "$1" = "maven" ]; then
         gauge_java_version=$(extract_gauge_java_version)


### PR DESCRIPTION
- Performing version validation results in increased startup time for the runner which causes LSP client to timeout.
- CLASSPATH calculation also increases startup time. Which can be avoided by setting the gauge_custom_classpath beforehand.

Signed-off-by: Dharmendra Singh <dharmenn@thoughtworks.com>