### PR TITLE
kill runner with exit:0 after grpc shutdown

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "0.7.13",
+    "version": "0.7.14",
     "description": "Java support for gauge",
     "install": {
         "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <projectVersion>0.7.13</projectVersion>
+        <projectVersion>0.7.14</projectVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/src/main/java/com/thoughtworks/gauge/RunnerServiceHandler.java
+++ b/src/main/java/com/thoughtworks/gauge/RunnerServiceHandler.java
@@ -394,9 +394,12 @@ public class RunnerServiceHandler extends RunnerImplBase {
     @Override
     public void kill(Messages.KillProcessRequest request, StreamObserver<Messages.Empty> responseObserver) {
         try {
+            Logger.debug("Killing Java runner...");
             responseObserver.onNext(Messages.Empty.newBuilder().build());
             responseObserver.onCompleted();
+            Logger.debug("Stopping execution pool...");
             pool.stopAfterCompletion();
+            Logger.debug("Shutting down grpc server...");
             server.shutdownNow();
         } catch (Throwable e) {
             Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.KillProcessRequest, e.toString()));

--- a/src/main/java/com/thoughtworks/gauge/command/StartCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/command/StartCommand.java
@@ -59,5 +59,7 @@ public class StartCommand implements GaugeJavaCommand {
         Logger.debug("started gRPC server on port " + port);
         Logger.info("Listening on port:" + port);
         server.awaitTermination();
+        Logger.debug("Runner killed gracefully.");
+        System.exit(0);
     }
 }


### PR DESCRIPTION
user code can fork long running/indefinite thread which blocks process kill

add debug logging

fixes #553

Signed-off-by: sriv <srikanth.ddit@gmail.com>
