### PR TITLE
Upgrade checkout, setup-java. Remove hub

### DIFF
--- a/.github/workflows/release_on_pr.yml
+++ b/.github/workflows/release_on_pr.yml
@@ -15,14 +15,11 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: '12.x.x'
-
-      - name: Install hub
-        uses: geertvdc/setup-hub@master
 
       - name: Setup maven
         run: |
@@ -38,7 +35,7 @@ jobs:
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
 
       - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
         id: go    


### PR DESCRIPTION
Upgrade checkout and setup actions to newer versions
Remove geervdc/hub because hub is available by default
and geervdc uses deprecated github actions

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>