### PR TITLE
Downgrades grpc dependencies to < 1.42.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ gauge run specs
 #### Install specific version
 * Installing specific version
 ```
-gauge install java --version 0.9.0
+gauge install java --version 0.9.1
 ```
 
 #### Offline installation
 * Download the plugin from [Releases](https://github.com/getgauge/gauge-java/releases)
 ```
-gauge install java --file gauge-java-0.9.0-windows.x86_64.zip
+gauge install java --file gauge-java-0.9.1-windows.x86_64.zip
 ```
 
 #### Build from source

--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "Java support for gauge",
     "install": {
         "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -82,17 +82,17 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>1.45.0</version>
+            <version>1.41.2</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>1.45.0</version>
+            <version>1.41.2</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>1.45.0</version>
+            <version>1.41.2</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
@@ -303,7 +303,7 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <projectVersion>0.9.0</projectVersion>
+        <projectVersion>0.9.1</projectVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
The gauge-java version 0.8.x bumped the version of grpc dependencies to > 1.41.x which is currently breaking the gauge running on latest alpine images. Fixes #674

The issue is detailed in https://github.com/grpc/grpc-java/issues/8751

There is a workaround to grpc working within the alpine images but that causes issues with other musl binaries on the image.

This PR is pinning to last working version `1.41.2`.