### PR TITLE
Use InheritableThreadLocal in datastores

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ gauge run specs
 #### Install specific version
 * Installing specific version
 ```
-gauge install java --version 0.9.1
+gauge install java --version 0.9.2
 ```
 
 #### Offline installation
 * Download the plugin from [Releases](https://github.com/getgauge/gauge-java/releases)
 ```
-gauge install java --file gauge-java-0.9.1-windows.x86_64.zip
+gauge install java --file gauge-java-0.9.2-windows.x86_64.zip
 ```
 
 #### Build from source

--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "Java support for gauge",
     "install": {
         "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <projectVersion>0.9.1</projectVersion>
+        <projectVersion>0.9.2</projectVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/src/main/java/com/thoughtworks/gauge/datastore/DataStore.java
+++ b/src/main/java/com/thoughtworks/gauge/datastore/DataStore.java
@@ -8,7 +8,14 @@ package com.thoughtworks.gauge.datastore;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
+/**
+ * @deprecated DataStore is no longer valid. The usage together with DataStoreFactory API will throw an Exception in multithreaded execution.
+ * <p>Use specific data stores instead.</p>
+ * @see com.thoughtworks.gauge.datastore.SuiteDataStore
+ * @see com.thoughtworks.gauge.datastore.SpecDataStore
+ * @see com.thoughtworks.gauge.datastore.ScenarioDataStore
+ */
+@Deprecated
 public class DataStore {
 
     private HashMap<Object, Object> map = new HashMap<>();

--- a/src/main/java/com/thoughtworks/gauge/datastore/ScenarioDataStore.java
+++ b/src/main/java/com/thoughtworks/gauge/datastore/ScenarioDataStore.java
@@ -11,7 +11,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ScenarioDataStore {
-    private static ThreadLocal<ConcurrentHashMap<Object, Object>> map = ThreadLocal.withInitial(ConcurrentHashMap::new);
+    private static final InheritableThreadLocal<ConcurrentHashMap<Object, Object>> MAP = new InheritableThreadLocal<ConcurrentHashMap<Object, Object>>() {
+        @Override
+        protected ConcurrentHashMap<Object, Object> initialValue() {
+            return new ConcurrentHashMap<>();
+        }
+    };
 
     /**
      * @param key   - Key of the data entry
@@ -19,7 +24,7 @@ public class ScenarioDataStore {
      */
     public static synchronized void put(Object key, Object value) {
         if (key != null && value != null)  {
-            map.get().put(key, value);
+            MAP.get().put(key, value);
         }
     }
 
@@ -29,7 +34,7 @@ public class ScenarioDataStore {
      */
     public static synchronized Object remove(Object key) {
         if (key != null) {
-            return map.get().remove(key);
+            return MAP.get().remove(key);
         }
         return null;
     }
@@ -40,7 +45,7 @@ public class ScenarioDataStore {
      */
     public static synchronized Object get(Object key) {
         if (key != null) {
-            return map.get().get(key);
+            return MAP.get().get(key);
         }
         return null;
     }
@@ -50,11 +55,11 @@ public class ScenarioDataStore {
      * @return A set of keys stored in datastore
      */
     public static synchronized Set<Object> items() {
-        return Collections.unmodifiableSet(map.get().keySet());
+        return Collections.unmodifiableSet(MAP.get().keySet());
     }
 
     static synchronized void clear() {
-        map.get().clear();
+        MAP.get().clear();
     }
 
 }

--- a/src/main/java/com/thoughtworks/gauge/datastore/SpecDataStore.java
+++ b/src/main/java/com/thoughtworks/gauge/datastore/SpecDataStore.java
@@ -11,15 +11,19 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SpecDataStore {
-    private static ThreadLocal<ConcurrentHashMap<Object, Object>> map = ThreadLocal.withInitial(ConcurrentHashMap::new);
-
+    private static final InheritableThreadLocal<ConcurrentHashMap<Object, Object>> MAP = new InheritableThreadLocal<ConcurrentHashMap<Object, Object>>() {
+        @Override
+        protected ConcurrentHashMap<Object, Object> initialValue() {
+            return new ConcurrentHashMap<>();
+        }
+    };
     /**
      * @param key   - Key of the data entry
      * @param value - value of the Data entry
      */
     public static synchronized void put(Object key, Object value) {
         if (key != null && value != null)  {
-            map.get().put(key, value);
+            MAP.get().put(key, value);
         }
     }
 
@@ -29,7 +33,7 @@ public class SpecDataStore {
      */
     public static synchronized Object remove(Object key) {
         if (key != null) {
-            return map.get().remove(key);
+            return MAP.get().remove(key);
         }
         return null;
     }
@@ -40,7 +44,7 @@ public class SpecDataStore {
      */
     public static synchronized Object get(Object key) {
         if (key != null) {
-            return map.get().get(key);
+            return MAP.get().get(key);
         }
         return null;
     }
@@ -50,10 +54,10 @@ public class SpecDataStore {
      * @return A set of keys stored in datastore
      */
     public static synchronized Set<Object> items() {
-        return Collections.unmodifiableSet(map.get().keySet());
+        return Collections.unmodifiableSet(MAP.get().keySet());
     }
 
     static synchronized void clear() {
-        map.get().clear();
+        MAP.get().clear();
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/datastore/SuiteDataStore.java
+++ b/src/main/java/com/thoughtworks/gauge/datastore/SuiteDataStore.java
@@ -11,7 +11,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SuiteDataStore {
-    private static ThreadLocal<ConcurrentHashMap<Object, Object>> map = ThreadLocal.withInitial(ConcurrentHashMap::new);
+    private static final InheritableThreadLocal<ConcurrentHashMap<Object, Object>> MAP = new InheritableThreadLocal<ConcurrentHashMap<Object, Object>>() {
+        @Override
+        protected ConcurrentHashMap<Object, Object> initialValue() {
+            return new ConcurrentHashMap<>();
+        }
+    };
 
     /**
      * @param key   - Key of the data entry
@@ -19,7 +24,7 @@ public class SuiteDataStore {
      */
     public static synchronized void put(Object key, Object value) {
         if (key != null && value != null)  {
-            map.get().put(key, value);
+            MAP.get().put(key, value);
         }
     }
 
@@ -29,7 +34,7 @@ public class SuiteDataStore {
      */
     public static synchronized Object remove(Object key) {
         if (key != null) {
-            return map.get().remove(key);
+            return MAP.get().remove(key);
         }
         return null;
     }
@@ -40,7 +45,7 @@ public class SuiteDataStore {
      */
     public static synchronized Object get(Object key) {
         if (key != null) {
-            return map.get().get(key);
+            return MAP.get().get(key);
         }
         return null;
     }
@@ -50,10 +55,10 @@ public class SuiteDataStore {
      * @return A set of keys stored in datastore
      */
     public static synchronized Set<Object> items() {
-        return Collections.unmodifiableSet(map.get().keySet());
+        return Collections.unmodifiableSet(MAP.get().keySet());
     }
 
     static synchronized void clear() {
-        map.get().clear();
+        MAP.get().clear();
     }
 }


### PR DESCRIPTION
When datastores values are saved in a spec step and retrieved in a child thread e.g. which spanned by [awaitability](http://www.awaitility.org/) the value is not retrieved from that thread correctly. InheritableTheadLocal solved this issue. 