### PR TITLE
Bump golang and further dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release_on_pr.yml
+++ b/.github/workflows/release_on_pr.yml
@@ -35,10 +35,10 @@ jobs:
           git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
         id: go    
 
       - name: Build artifacts

--- a/.github/workflows/release_on_pr.yml
+++ b/.github/workflows/release_on_pr.yml
@@ -15,11 +15,11 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup maven
@@ -36,9 +36,9 @@ jobs:
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
 
       - name: Set up Go 1.20
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
         id: go    
 
       - name: Build artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java_version: ['11', '17']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
-          distribution: 'adopt'
 
 
       - name: Run test
@@ -39,13 +39,13 @@ jobs:
         os: [windows-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: '17'
-          distribution: 'adopt'
 
       - uses: getgauge/setup-gauge@master
         with:
@@ -90,18 +90,18 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup go 1.20
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: '17'
-          distribution: 'adopt'
 
       - uses: getgauge/setup-gauge@master
         with:
@@ -113,9 +113,9 @@ jobs:
           go run build/make.go --install
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Prep LSP tests
         run: |
           git clone https://github.com/getgauge/gauge-lsp-tests
@@ -141,12 +141,12 @@ jobs:
     needs: [functional_tests, lsp-tests]
     steps:
       - name: Set up Go 1.20
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
         id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build distro for ${{ matrix.os }}
         run: go run build/make.go --all-platforms && go run build/make.go --all-platforms --distro

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,10 +92,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup go 1.17
+      - name: Setup go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Setup java
         uses: actions/setup-java@v2
@@ -140,10 +140,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [functional_tests, lsp-tests]
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ gauge run specs
 #### Install specific version
 * Installing specific version
 ```
-gauge install java --version 0.10.0
+gauge install java --version 0.10.1
 ```
 
 #### Offline installation
 * Download the plugin from [Releases](https://github.com/getgauge/gauge-java/releases)
 ```
-gauge install java --file gauge-java-0.10.0-windows.x86_64.zip
+gauge install java --file gauge-java-0.10.1-windows.x86_64.zip
 ```
 
 #### Build from source
@@ -58,13 +58,13 @@ Apart from [Gauge](https://gauge.org/index.html) and [Java](https://www.java.com
 ##### Compiling
 
 ````
-go run make.go
+go run build/make.go
 ````	
 
 For cross platform compilation (launcher)	
 
 ````	
-go run make.go --all-platforms
+go run build/make.go --all-platforms
 ````
 
 ##### Installing
@@ -72,28 +72,28 @@ go run make.go --all-platforms
 After compilation
 
 ````	
-go run make.go --install	
+go run build/make.go --install	
 ````	
 
 Installing to a CUSTOM_LOCATION	
 
 
 ````
-go run make.go --install --plugin-prefix CUSTOM_LOCATION
+go run build/make.go --install --plugin-prefix CUSTOM_LOCATION
 ````
 
 ##### Creating distributable
 
 Note: Run after compiling
 ````	
-go run make.go --distro	
+go run build/make.go --distro	
 ````	
 
 
 For distributable across platforms os, windows and linux for bith x86 and x86_64	
 
 ````	
-go run make.go --distro --all-platforms	
+go run build/make.go --distro --all-platforms	
 ````
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/getgauge/gauge-java
 
-go 1.13
+go 1.20

--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "Java support for gauge",
     "install": {
         "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
             <version>2.13.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.1-jre</version>
+            <version>32.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <projectVersion>0.10.0</projectVersion>
+        <projectVersion>0.10.1</projectVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>

--- a/src/main/java/com/thoughtworks/gauge/Logger.java
+++ b/src/main/java/com/thoughtworks/gauge/Logger.java
@@ -5,7 +5,7 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONObject;
 
 public class Logger {

--- a/src/main/java/com/thoughtworks/gauge/Table.java
+++ b/src/main/java/com/thoughtworks/gauge/Table.java
@@ -9,7 +9,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/thoughtworks/gauge/Util.java
+++ b/src/main/java/com/thoughtworks/gauge/Util.java
@@ -7,7 +7,7 @@ package com.thoughtworks.gauge;
 
 import java.io.File;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class Util {
     public static File workingDir() {

--- a/src/main/java/com/thoughtworks/gauge/execution/parameters/DynamicParametersReplacer.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/parameters/DynamicParametersReplacer.java
@@ -6,7 +6,7 @@
 package com.thoughtworks.gauge.execution.parameters;
 
 import gauge.messages.Spec;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.regex.Matcher;

--- a/src/main/java/com/thoughtworks/gauge/refactor/JavaRefactoring.java
+++ b/src/main/java/com/thoughtworks/gauge/refactor/JavaRefactoring.java
@@ -13,7 +13,7 @@ import com.thoughtworks.gauge.StepValue;
 import com.thoughtworks.gauge.Util;
 import com.thoughtworks.gauge.registry.StepRegistry;
 import gauge.messages.Messages;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/com/thoughtworks/gauge/refactor/RefactoringMethodVisitor.java
+++ b/src/main/java/com/thoughtworks/gauge/refactor/RefactoringMethodVisitor.java
@@ -23,7 +23,7 @@ import com.thoughtworks.gauge.Logger;
 import com.thoughtworks.gauge.StepValue;
 import com.thoughtworks.gauge.Util;
 import gauge.messages.Messages;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;


### PR DESCRIPTION
* Bumps building golang 1.17 -> 1.20
* Bumps commons-lang and guava
* Adds back dependabot