### PR TITLE
Fixes an issue with gradle command from a multimodule project

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "Java support for gauge",
     "install": {
         "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <projectVersion>0.10.1</projectVersion>
+        <projectVersion>0.10.2</projectVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>


### PR DESCRIPTION
Currently if gauge is executed from a submodule, then it doesn't find the project's gradle wrapper.

- Uses the project root's gradle wrapper if not found from within gauge projectRoot
- Adds `gauge_dependency_validation` property so we can skip the validation if not required.