### PR TITLE
Log4j2 Logging

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>0.11.3</version>
+    <version>0.12.0</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.24.3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -83,6 +90,14 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>0.11.2</version>
+    <version>0.11.3</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>

--- a/src/main/java/com/thoughtworks/gauge/FileHelper.java
+++ b/src/main/java/com/thoughtworks/gauge/FileHelper.java
@@ -5,6 +5,9 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -22,6 +25,9 @@ import static com.thoughtworks.gauge.GaugeConstant.GAUGE_PROJECT_ROOT;
 import static com.thoughtworks.gauge.GaugeConstant.DEFAULT_SRC_DIRS;
 
 public class FileHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger(FileHelper.class);
+
     private static final String CUSTOM_COMPILE_DIR_SEPARATOR = ",";
     private static final String JAVA_FILE_EXT = ".java";
 
@@ -35,7 +41,7 @@ public class FileHelper {
                     }
                 });
             } catch (IOException e) {
-                Logger.error("", e);
+                GaugeExceptionLogger.error(LOGGER, "", e);
             }
         });
         return outputFiles;

--- a/src/main/java/com/thoughtworks/gauge/GaugeExceptionLogger.java
+++ b/src/main/java/com/thoughtworks/gauge/GaugeExceptionLogger.java
@@ -1,0 +1,107 @@
+/*----------------------------------------------------------------
+ *  Copyright (c) ThoughtWorks, Inc.
+ *  Licensed under the Apache License, Version 2.0
+ *  See LICENSE.txt in the project root for license information.
+ *----------------------------------------------------------------*/
+package com.thoughtworks.gauge;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * Class responsible for logging exceptions thrown within the Gauge Java plugin.
+ */
+public class GaugeExceptionLogger {
+
+    /**
+     * Logs a warning message {@link Throwable}.
+     *
+     * @param logger The {@link Logger} that the {@link Throwable} will be logged under
+     * @param message The message to log with the {@link Throwable}
+     * @param throwable The {@link Throwable} being logged
+     */
+    public static void warning(Logger logger, String message, Throwable throwable) {
+        logThrowable(logger, Level.WARN, message, throwable);
+    }
+
+    /**
+     * Logs an error message {@link Throwable}.
+     *
+     * @param logger The {@link Logger} that the {@link Throwable} will be logged under
+     * @param message The message to log with the {@link Throwable}
+     * @param throwable The {@link Throwable} being logged
+     */
+    public static void error(Logger logger, String message, Throwable throwable) {
+        logThrowable(logger, Level.ERROR, message, throwable);
+    }
+
+    /**
+     * Logs a fatal message & {@link Throwable} and calls {@link System#exit}.
+     *
+     * @param logger The {@link Logger} that the {@link Throwable} will be logged under
+     * @param message The message to log with the {@link Throwable}
+     * @param throwable The {@link Throwable} being logged
+     */
+    public static void fatal(Logger logger, String message, Throwable throwable) {
+        logThrowable(logger, Level.FATAL, message, throwable);
+    }
+
+    /**
+     * Logs a fatal message and calls {@link System#exit}.
+     *
+     * @param logger The {@link Logger} that the message will be logged under
+     * @param message The message being logged
+     */
+    public static void fatal(Logger logger, String message) {
+        fatal(logger, message, null);
+    }
+
+    /**
+     * Logs a message & {@link Throwable}. If the {@link Level} provided is fatal, {@link System#exit} will be called.
+     *
+     * @param logger The {@link Logger} that the {@link Throwable} will be logged under
+     * @param level The {@link Level} to log the {@link Throwable} as
+     * @param message The message to log with the {@link Throwable}
+     * @param throwable The {@link Throwable} being logged
+     */
+    public static void logThrowable(Logger logger, Level level, String message, Throwable throwable) {
+        StringBuilder logMessageBuilder = new StringBuilder();
+
+        addMessageIfNotNull(logMessageBuilder, null, message);
+
+        // Don't want any null pointer exceptions
+        if (throwable != null) {
+            addMessageIfNotNull(logMessageBuilder, "Throwable Message: ", throwable.getMessage());
+            addMessageIfNotNull(logMessageBuilder, "Stacktrace: ", ExceptionUtils.getStackTrace(throwable));
+        }
+
+        logger.log(level, logMessageBuilder.toString().strip());
+
+        if (level == Level.FATAL) {
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Adds to the given {@link StringBuilder} if the message is not null.
+     *
+     * @param stringBuilder The {@link StringBuilder} to add to
+     * @param appendBefore Any {@link String} to append before the message
+     * @param message The message being appended
+     */
+    private static void addMessageIfNotNull(StringBuilder stringBuilder, String appendBefore, String message) {
+        Optional.ofNullable(message)
+                .ifPresent(msg -> {
+                    if (appendBefore != null) {
+                        stringBuilder.append(appendBefore);
+                    }
+                    stringBuilder.append(message).append("\n");
+                });
+    }
+
+
+
+}

--- a/src/main/java/com/thoughtworks/gauge/GaugeRuntime.java
+++ b/src/main/java/com/thoughtworks/gauge/GaugeRuntime.java
@@ -6,14 +6,19 @@
 package com.thoughtworks.gauge;
 
 import com.thoughtworks.gauge.command.GaugeCommandFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Holds Main for starting Gauge-java 1. Makes connections to gauge 2. Scans
  * Classpath 3. Dispatched all message responses
  */
 public class GaugeRuntime {
+
+    private static final Logger LOGGER = LogManager.getLogger(GaugeRuntime.class);
+
     public static void main(String[] args) throws Exception {
-        Thread.setDefaultUncaughtExceptionHandler((t, e) -> Logger.fatal("Error in thread " + t.getId(), e));
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> GaugeExceptionLogger.fatal(LOGGER, "Error in thread " + t.getId(), e));
         if (args.length == 0) {
             System.out.println("usage: GaugeJava --<start|init>");
             System.exit(1);

--- a/src/main/java/com/thoughtworks/gauge/Logger.java
+++ b/src/main/java/com/thoughtworks/gauge/Logger.java
@@ -6,55 +6,91 @@
 package com.thoughtworks.gauge;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.json.JSONObject;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
+/**
+ * @deprecated Use a log4j2 {@link org.apache.logging.log4j.Logger} to log any required messages.
+ *             Additionally {@link GaugeExceptionLogger} is available to log exceptions
+ */
+@Deprecated
 public class Logger {
+
+    private static final org.apache.logging.log4j.Logger LOGGER = LogManager.getLogger(Logger.class);
+
+    /**
+     * @deprecated Use log4j2 {@link org.apache.logging.log4j.Logger#info}
+     */
+    @Deprecated
     public static void info(String message) {
         logToStdout("info", message);
     }
 
+    /**
+     * @deprecated Use log4j2 {@link org.apache.logging.log4j.Logger#error}
+     */
+    @Deprecated
     public static void error(String message) {
         logToStdErr("error", message);
     }
 
+    /**
+     * @deprecated Use {@link GaugeExceptionLogger#error}
+     */
+    @Deprecated
     public static void error(String message, Throwable t) {
         error(String.format("%s\n%s\n%s", message, t.getMessage(), ExceptionUtils.getStackTrace(t)));
     }
 
+    /**
+     * @deprecated Use log4j2 {@link org.apache.logging.log4j.Logger#warn}
+     */
+    @Deprecated
     public static void warning(String message) {
-        logToStdout("warning", message);
+        logToStdout("warn", message);
     }
 
+    /**
+     * @deprecated Use {@link GaugeExceptionLogger#warning}
+     */
+    @Deprecated
     public static void warning(String message, Throwable t) {
         warning(String.format("%s\n%s\n%s", message, t.getMessage(), ExceptionUtils.getStackTrace(t)));
     }
 
+    /**
+     * @deprecated Use log4j2 {@link org.apache.logging.log4j.Logger#debug}
+     */
+    @Deprecated
     public static void debug(String message) {
         logToStdout("debug", message);
     }
 
+    /**
+     * @deprecated Use {@link GaugeExceptionLogger#fatal(org.apache.logging.log4j.Logger, String)}
+     */
+    @Deprecated
     public static void fatal(String message) {
         logToStdErr("fatal", message);
         System.exit(1);
     }
 
+    /**
+     * @deprecated Use {@link GaugeExceptionLogger#fatal(org.apache.logging.log4j.Logger, String, Throwable)}
+     */
+    @Deprecated
     public static void fatal(String message, Throwable t) {
         fatal(String.format("%s\n%s\n%s", message, t.getMessage(), ExceptionUtils.getStackTrace(t)));
 
     }
 
+    @Deprecated
     private static void logToStdout(String level, String message) {
-        System.out.println(getJsonObject(level, message));
+        LOGGER.log(Level.valueOf(level), message);
     }
 
-    private static JSONObject getJsonObject(String level, String message) {
-        JSONObject jsonObj = new JSONObject();
-        jsonObj.put("logLevel", level);
-        jsonObj.put("message", message);
-        return jsonObj;
-    }
-
+    @Deprecated
     private static void logToStdErr(String level, String message) {
-        System.err.println(getJsonObject(level, message));
+        LOGGER.log(Level.valueOf(level), message);
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/RunnerServiceHandler.java
+++ b/src/main/java/com/thoughtworks/gauge/RunnerServiceHandler.java
@@ -13,11 +13,16 @@ import gauge.messages.Messages.Message.MessageType;
 import gauge.messages.RunnerGrpc.RunnerImplBase;
 import io.grpc.Server;
 import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class RunnerServiceHandler extends RunnerImplBase {
+    private static final Logger LOGGER = LogManager.getLogger(RunnerServiceHandler.class);
+    private static final String ERROR_LOG_FORMAT = "Failed to process {}.\nReason: {}";
+
     private final MessageProcessorFactory messageProcessorFactory;
     private final boolean multithreading;
     private Server server;
@@ -46,7 +51,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.SuiteDataStoreInit, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.SuiteDataStoreInit, e.toString());
             responseObserver.onError(e);
         }
 
@@ -64,7 +69,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ExecutionStarting, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ExecutionStarting, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -81,7 +86,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.SpecDataStoreInit, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.SpecDataStoreInit, e.toString());
             responseObserver.onError(e);
         }
 
@@ -99,7 +104,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.SpecExecutionStarting, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.SpecExecutionStarting, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -116,7 +121,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ScenarioDataStoreInit, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ScenarioDataStoreInit, e.toString());
             responseObserver.onError(e);
         }
 
@@ -134,7 +139,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ScenarioExecutionStarting, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ScenarioExecutionStarting, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -151,7 +156,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StepExecutionEnding, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StepExecutionEnding, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -168,7 +173,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ExecuteStep, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ExecuteStep, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -185,7 +190,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StepExecutionEnding, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StepExecutionEnding, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -202,7 +207,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ScenarioExecutionEnding, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ScenarioExecutionEnding, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -219,7 +224,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.SpecExecutionEnding, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.SpecExecutionEnding, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -236,7 +241,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ExecutionEnding, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ExecutionEnding, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -254,7 +259,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StepNameRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StepNameRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -271,7 +276,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.CacheFileRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.CacheFileRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -288,7 +293,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StepPositionsRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StepPositionsRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -302,7 +307,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ImplementationFileListRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ImplementationFileListRequest, e.toString());
             responseObserver.onError(e);
         }
 
@@ -320,7 +325,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StubImplementationCodeRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StubImplementationCodeRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -337,7 +342,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StepValidateRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StepValidateRequest, e.toString());
             responseObserver.onError(e);
         }
 
@@ -355,7 +360,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.RefactorRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.RefactorRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -372,7 +377,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.StepNameRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.StepNameRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -386,7 +391,7 @@ public class RunnerServiceHandler extends RunnerImplBase {
                 responseObserver.onCompleted();
             });
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.ImplementationFileGlobPatternRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.ImplementationFileGlobPatternRequest, e.toString());
             responseObserver.onError(e);
         }
     }
@@ -394,15 +399,15 @@ public class RunnerServiceHandler extends RunnerImplBase {
     @Override
     public void kill(Messages.KillProcessRequest request, StreamObserver<Messages.Empty> responseObserver) {
         try {
-            Logger.debug("Killing Java runner...");
+            LOGGER.debug("Killing Java runner...");
             responseObserver.onNext(Messages.Empty.newBuilder().build());
             responseObserver.onCompleted();
-            Logger.debug("Stopping execution pool...");
+            LOGGER.debug("Stopping execution pool...");
             pool.stopAfterCompletion();
-            Logger.debug("Shutting down grpc server...");
+            LOGGER.debug("Shutting down grpc server...");
             server.shutdownNow();
         } catch (Throwable e) {
-            Logger.error(String.format("Failed to process %s.\nReason: %s", MessageType.KillProcessRequest, e.toString()));
+            LOGGER.error(ERROR_LOG_FORMAT, MessageType.KillProcessRequest, e.toString());
             responseObserver.onError(e);
         }
     }

--- a/src/main/java/com/thoughtworks/gauge/command/SetupCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/command/SetupCommand.java
@@ -5,7 +5,8 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.command;
 
-import com.thoughtworks.gauge.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -14,6 +15,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
 public class SetupCommand implements GaugeJavaCommand {
+
+    private static final Logger LOGGER = LogManager.getLogger(SetupCommand.class);
 
     @Override
     public void execute() throws IOException {
@@ -104,7 +107,7 @@ public class SetupCommand implements GaugeJavaCommand {
     }
 
     private void writeContent(Path templateFilePath, String content) throws IOException {
-        Logger.info(String.format("create %s", templateFilePath.toString()));
+        LOGGER.info("create {}", templateFilePath.toString());
         Files.writeString(templateFilePath, content, StandardOpenOption.APPEND);
     }
 

--- a/src/main/java/com/thoughtworks/gauge/command/StartCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/command/StartCommand.java
@@ -5,12 +5,13 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.command;
 
-import com.thoughtworks.gauge.Logger;
 import com.thoughtworks.gauge.RunnerServiceHandler;
 import com.thoughtworks.gauge.connection.MessageProcessorFactory;
 import com.thoughtworks.gauge.scan.StaticScanner;
 import io.grpc.Server;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.net.InetSocketAddress;
 
@@ -18,20 +19,22 @@ import static com.thoughtworks.gauge.GaugeConstant.*;
 
 public class StartCommand implements GaugeJavaCommand {
 
+    private static final Logger LOGGER = LogManager.getLogger(StartCommand.class);
+
     @Override
     public void execute() throws Exception {
         boolean multithreading = Boolean.parseBoolean(System.getenv(ENABLE_MULTITHREADING_ENV));
-        Logger.debug("multithreading is set to " + multithreading);
+        LOGGER.debug("multithreading is set to {}", multithreading);
         int numberOfStreams = 1;
 
         if (multithreading) {
             String streamsCount = System.getenv(STREAMS_COUNT_ENV);
             try {
                 numberOfStreams = Integer.parseInt(streamsCount);
-                Logger.debug("multithreading enabled, number of threads=" + numberOfStreams);
+                LOGGER.debug("multithreading enabled, number of threads={}", numberOfStreams);
             } catch (NumberFormatException e) {
-                Logger.debug("multithreading enabled, but could not read " + STREAMS_COUNT_ENV + " as int. Got " + STREAMS_COUNT_ENV + "=" + streamsCount);
-                Logger.debug("using numberOfStreams=1, err: " + e.getMessage());
+                LOGGER.debug("multithreading enabled, but could not read " + STREAMS_COUNT_ENV + " as int. Got " + STREAMS_COUNT_ENV + "={}", streamsCount);
+                LOGGER.debug("using numberOfStreams=1, err: {}", e.getMessage());
             }
         }
 
@@ -48,15 +51,15 @@ public class StartCommand implements GaugeJavaCommand {
             .build();
         runnerServiceHandler.addServer(server);
         long elapsed = System.currentTimeMillis() - start;
-        Logger.debug("gauge-java took " + elapsed + "milliseconds to load and scan. This should be less than 'runner_connection_timeout' config value.");
-        Logger.debug("run 'gauge config runner_connection_timeout' and verify that it is < " + elapsed);
-        Logger.debug("starting gRPC server...");
+        LOGGER.debug("gauge-java took {} milliseconds to load and scan. This should be less than 'runner_connection_timeout' config value.", elapsed);
+        LOGGER.debug("run 'gauge config runner_connection_timeout' and verify that it is < {}", elapsed);
+        LOGGER.debug("starting gRPC server...");
         server.start();
         int port = server.getPort();
-        Logger.debug("started gRPC server on port " + port);
-        Logger.info("Listening on port:" + port);
+        LOGGER.debug("started gRPC server on port {}", port);
+        LOGGER.info("Listening on port:{}", port);
         server.awaitTermination();
-        Logger.debug("Runner killed gracefully.");
+        LOGGER.debug("Runner killed gracefully.");
         System.exit(0);
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/connection/StubImplementationCodeProcessor.java
+++ b/src/main/java/com/thoughtworks/gauge/connection/StubImplementationCodeProcessor.java
@@ -14,9 +14,11 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import com.google.protobuf.ProtocolStringList;
 import com.thoughtworks.gauge.FileHelper;
-import com.thoughtworks.gauge.Logger;
+import com.thoughtworks.gauge.GaugeExceptionLogger;
 import gauge.messages.Messages;
 import gauge.messages.Spec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileReader;
@@ -26,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class StubImplementationCodeProcessor implements com.thoughtworks.gauge.processor.IMessageProcessor {
+
+    private static final Logger LOGGER = LogManager.getLogger(StubImplementationCodeProcessor.class);
     private static final String NEW_LINE = "\n";
     private static final List<MethodDeclaration> METHOD_DECLARATIONS = new ArrayList<>();
     private static Range classRange;
@@ -62,7 +66,7 @@ public class StubImplementationCodeProcessor implements com.thoughtworks.gauge.p
             }
             return implementInNewClass(stubs, file);
         } catch (IOException e) {
-            Logger.error("Unable to implement method", e);
+            GaugeExceptionLogger.error(LOGGER, "Unable to implement method", e);
         }
         return null;
     }
@@ -121,7 +125,7 @@ public class StubImplementationCodeProcessor implements com.thoughtworks.gauge.p
             return Messages.FileDiff.newBuilder().setFilePath(file.toString()).addTextDiffs(textDiff).build();
 
         } catch (IOException e) {
-            Logger.error("Unable to implement method", e);
+            GaugeExceptionLogger.error(LOGGER, "Unable to implement method", e);
         }
         return null;
     }

--- a/src/main/java/com/thoughtworks/gauge/execution/MethodExecutor.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/MethodExecutor.java
@@ -7,9 +7,13 @@ package com.thoughtworks.gauge.execution;
 
 import com.thoughtworks.gauge.ClassInstanceManager;
 import com.thoughtworks.gauge.ContinueOnFailure;
+import com.thoughtworks.gauge.GaugeExceptionLogger;
 import com.thoughtworks.gauge.Util;
 import com.thoughtworks.gauge.screenshot.ScreenshotFactory;
 import gauge.messages.Spec;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -17,6 +21,7 @@ import java.lang.reflect.Method;
 import java.util.Set;
 
 public class MethodExecutor {
+    private static final Logger LOGGER = LogManager.getLogger(MethodExecutor.class);
     private final ClassInstanceManager instanceManager;
 
     public MethodExecutor(ClassInstanceManager instanceManager) {
@@ -37,21 +42,25 @@ public class MethodExecutor {
                 continuableExceptions = method.getAnnotation(ContinueOnFailure.class).value();
             }
             long endTime = System.currentTimeMillis();
-            return createFailureExecResult(endTime - startTime, e, recoverable, continuableExceptions);
+            return createFailureExecResult(method.getName(), endTime - startTime, e, recoverable, continuableExceptions);
         }
     }
 
-    private Spec.ProtoExecutionResult createFailureExecResult(long execTime, Throwable e, boolean recoverable, Class[] continuableExceptions) {
+    private Spec.ProtoExecutionResult createFailureExecResult(String methodName, long execTime, Throwable e, boolean recoverable, Class[] continuableExceptions) {
         Spec.ProtoExecutionResult.Builder builder = Spec.ProtoExecutionResult.newBuilder().setFailed(true);
         if (Util.shouldTakeFailureScreenshot()) {
             String screenshotFileName = new ScreenshotFactory(instanceManager).getScreenshotBytes();
             builder.setFailureScreenshotFile(screenshotFileName);
         }
+
+        Level logLevel = Level.ERROR;
+
         if (e.getCause() != null) {
             builder.setRecoverableError(false);
             for (Class c : continuableExceptions) {
                 if (c.isAssignableFrom(e.getCause().getClass()) && recoverable) {
                     builder.setRecoverableError(true);
+                    logLevel = Level.INFO;
                     break;
                 }
             }
@@ -62,6 +71,9 @@ public class MethodExecutor {
             builder.setErrorMessage(e.toString());
             builder.setStackTrace(formatStackTrace(e));
         }
+
+        String logMessage = String.format("Method with name %s threw a%srecoverable exception", methodName, builder.getRecoverableError() ? " " : "n un");
+        GaugeExceptionLogger.logThrowable(LOGGER, logLevel, logMessage, e);
         builder.setExecutionTime(execTime);
         return builder.build();
     }

--- a/src/main/java/com/thoughtworks/gauge/execution/parameters/parsers/base/ParameterParsingChain.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/parameters/parsers/base/ParameterParsingChain.java
@@ -6,7 +6,7 @@
 package com.thoughtworks.gauge.execution.parameters.parsers.base;
 
 import com.thoughtworks.gauge.ClasspathHelper;
-import com.thoughtworks.gauge.Logger;
+import com.thoughtworks.gauge.GaugeExceptionLogger;
 import com.thoughtworks.gauge.execution.parameters.ParsingException;
 import com.thoughtworks.gauge.execution.parameters.parsers.converters.TableConverter;
 import com.thoughtworks.gauge.execution.parameters.parsers.types.EnumParameterParser;
@@ -14,6 +14,8 @@ import com.thoughtworks.gauge.execution.parameters.parsers.types.PrimitiveParame
 import com.thoughtworks.gauge.execution.parameters.parsers.types.PrimitivesConverter;
 import com.thoughtworks.gauge.execution.parameters.parsers.types.TableParameterParser;
 import gauge.messages.Spec.Parameter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.reflections.Configuration;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
@@ -27,6 +29,7 @@ import java.util.Objects;
 
 public class ParameterParsingChain implements ParameterParser {
 
+    private static final Logger LOGGER = LogManager.getLogger(ParameterParsingChain.class);
     private final List<ParameterParser> chain = new LinkedList<>();
 
     public ParameterParsingChain() {
@@ -51,10 +54,10 @@ public class ParameterParsingChain implements ParameterParser {
     ParameterParser asCustomParameterParser(Class<? extends ParameterParser> clazz) {
         try {
             ParameterParser instance = clazz.newInstance();
-            Logger.debug(String.format("Adding %s as custom parameter parser", clazz.getName()));
+            LOGGER.debug("Adding {} as custom parameter parser", clazz.getName());
             return instance;
         } catch (InstantiationException | IllegalAccessException e) {
-            Logger.error(String.format("Cannot add %s as custom parameter parser", clazz.getName()), e);
+            GaugeExceptionLogger.error(LOGGER, String.format("Cannot add %s as custom parameter parser", clazz.getName()), e);
             return null;
         }
     }

--- a/src/main/java/com/thoughtworks/gauge/processor/ExecuteStepProcessor.java
+++ b/src/main/java/com/thoughtworks/gauge/processor/ExecuteStepProcessor.java
@@ -5,10 +5,7 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.processor;
 
-import com.thoughtworks.gauge.ClassInstanceManager;
-import com.thoughtworks.gauge.Logger;
-import com.thoughtworks.gauge.MessageCollector;
-import com.thoughtworks.gauge.ScreenshotCollector;
+import com.thoughtworks.gauge.*;
 import com.thoughtworks.gauge.execution.ExecutionPipeline;
 import com.thoughtworks.gauge.execution.HookExecutionStage;
 import com.thoughtworks.gauge.execution.StepExecutionStage;
@@ -17,10 +14,14 @@ import com.thoughtworks.gauge.registry.HooksRegistry;
 import com.thoughtworks.gauge.registry.StepRegistry;
 import gauge.messages.Messages;
 import gauge.messages.Spec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Method;
 
 public class ExecuteStepProcessor extends MethodExecutionMessageProcessor implements IMessageProcessor {
+
+    private static final Logger LOGGER = LogManager.getLogger(ExecuteStepProcessor.class);
 
     private final ParameterParsingChain chain;
     private final StepRegistry registry;
@@ -35,9 +36,9 @@ public class ExecuteStepProcessor extends MethodExecutionMessageProcessor implem
         String stepText = message.getExecuteStepRequest().getParsedStepText();
         Method method = registry.get(stepText).getMethodInfo();
         if (method == null) {
-            Logger.fatal("No step definition found. Try compiling the source before execution.");
+            GaugeExceptionLogger.fatal(LOGGER, "No step definition found. Try compiling the source before execution.");
         }
-        Logger.debug("Executing '" + stepText + "' using '" + method.getDeclaringClass() + "." + method.getName());
+        LOGGER.debug("Executing '{}' using '{}.{}", stepText, method.getDeclaringClass(), method.getName());
         ExecutionPipeline pipeline = new ExecutionPipeline(new HookExecutionStage(HooksRegistry.getBeforeClassStepsHooksOfClass(method.getDeclaringClass()), getInstanceManager()));
         pipeline.addStages(new StepExecutionStage(message.getExecuteStepRequest(), getInstanceManager(), chain, registry),
                 new HookExecutionStage(HooksRegistry.getAfterClassStepsHooksOfClass(method.getDeclaringClass()), getInstanceManager()));

--- a/src/main/java/com/thoughtworks/gauge/refactor/JavaParseWorker.java
+++ b/src/main/java/com/thoughtworks/gauge/refactor/JavaParseWorker.java
@@ -5,10 +5,10 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.refactor;
 
-
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.thoughtworks.gauge.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -16,6 +16,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 public class JavaParseWorker extends Thread {
+
+    private static final Logger LOGGER = LogManager.getLogger(JavaParseWorker.class);
 
     public static final Charset CHARSET = StandardCharsets.UTF_8;
     private final File javaFile;
@@ -30,7 +32,7 @@ public class JavaParseWorker extends Thread {
             Optional<CompilationUnit> result = new JavaParser().parse(javaFile).getResult();
             result.ifPresent(value -> compilationUnit = value);
         } catch (Exception e) {
-            Logger.error("Unable to parse file " + javaFile.getName());
+            LOGGER.error("Unable to parse file {}", javaFile.getName());
         }
     }
 

--- a/src/main/java/com/thoughtworks/gauge/refactor/RefactoringMethodVisitor.java
+++ b/src/main/java/com/thoughtworks/gauge/refactor/RefactoringMethodVisitor.java
@@ -14,11 +14,13 @@ import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
-import com.thoughtworks.gauge.Logger;
+import com.thoughtworks.gauge.GaugeExceptionLogger;
 import com.thoughtworks.gauge.StepValue;
 import com.thoughtworks.gauge.Util;
 import gauge.messages.Messages;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -28,6 +30,8 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 public class RefactoringMethodVisitor extends VoidVisitorAdapter {
+
+    private static final Logger LOGGER = LogManager.getLogger(RefactoringMethodVisitor.class);
     private final StepValue oldStepValue;
     private final StepValue newStepValue;
     private final List<Messages.ParameterPosition> paramPositions;
@@ -78,7 +82,7 @@ public class RefactoringMethodVisitor extends VoidVisitorAdapter {
                 }
             }
         } catch (Exception e) {
-            Logger.error("Exception while refactoring", e);
+            GaugeExceptionLogger.error(LOGGER, "Exception while refactoring", e);
         }
     }
 

--- a/src/main/java/com/thoughtworks/gauge/registry/HooksRegistry.java
+++ b/src/main/java/com/thoughtworks/gauge/registry/HooksRegistry.java
@@ -7,6 +7,8 @@ package com.thoughtworks.gauge.registry;
 
 import com.thoughtworks.gauge.*;
 import com.thoughtworks.gauge.hook.Hook;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -17,6 +19,9 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toList;
 
 public class HooksRegistry {
+
+    private static final Logger LOGGER = LogManager.getLogger(HooksRegistry.class);
+
     // Names of methods defined in each Hook annotation. Do not rename these methods in any Hook Class.
     private static final String TAGS_METHOD = "tags";
     private static final String TAG_AGGREGATION_METHOD = "tagAggregation";
@@ -130,7 +135,7 @@ public class HooksRegistry {
                 Operator tagsAggregation = (Operator) annotation.getClass().getMethod(TAG_AGGREGATION_METHOD).invoke(annotation);
                 REGISTRY_MAP.get(hookClass).add(new Hook(method, tags, tagsAggregation));
             } catch (Exception e) {
-                Logger.warning("Unable to add hooks", e);
+                GaugeExceptionLogger.warning(LOGGER, "Unable to add hooks", e);
             }
         }
     }

--- a/src/main/java/com/thoughtworks/gauge/registry/StepRegistry.java
+++ b/src/main/java/com/thoughtworks/gauge/registry/StepRegistry.java
@@ -5,11 +5,12 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.registry;
 
-import com.thoughtworks.gauge.Logger;
 import com.thoughtworks.gauge.StepRegistryEntry;
 import com.thoughtworks.gauge.StepValue;
 import gauge.messages.Messages;
 import gauge.messages.Spec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -25,6 +26,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 public class StepRegistry {
+    private static final Logger LOGGER = LogManager.getLogger(StepRegistry.class);
     private ConcurrentHashMap<String, CopyOnWriteArrayList<StepRegistryEntry>> registry;
 
     public StepRegistry() {
@@ -43,7 +45,7 @@ public class StepRegistry {
 
     public List<String> keys() {
         return Collections.list(this.registry.keys());
-    };
+    }
 
     public boolean contains(String stepTemplateText) {
         return registry.containsKey(stepTemplateText);
@@ -57,8 +59,7 @@ public class StepRegistry {
         return registry.get(stepTemplateText).stream()
                 .filter(e -> {
                     String reflectedMethodName = method.getDeclaringClass().getName() + "." + method.getName();
-                    Logger.debug("Comparing '" + e.getFullyQualifiedName() + "' and '"
-                            + reflectedMethodName + "'");
+                    LOGGER.trace("Comparing '{}' and '{}'", e.getFullyQualifiedName(), reflectedMethodName);
                     return !e.getIsExternal() && e.getFullyQualifiedName().equals(reflectedMethodName);
                 })
                 .findFirst().orElse(null);

--- a/src/main/java/com/thoughtworks/gauge/scan/CustomClassInitializerScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/scan/CustomClassInitializerScanner.java
@@ -7,13 +7,17 @@ package com.thoughtworks.gauge.scan;
 
 import com.thoughtworks.gauge.ClassInitializer;
 import com.thoughtworks.gauge.DefaultClassInitializer;
-import com.thoughtworks.gauge.Logger;
 import com.thoughtworks.gauge.registry.ClassInitializerRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.reflections.Reflections;
 
 import java.util.Set;
 
 public class CustomClassInitializerScanner implements IScanner {
+
+    private static final Logger LOGGER = LogManager.getLogger(CustomClassInitializerScanner.class);
+
     @Override
     public void scan(Reflections reflections) {
         scanForInitializer(reflections);
@@ -26,16 +30,16 @@ public class CustomClassInitializerScanner implements IScanner {
             Class<? extends ClassInitializer> initializer = initializers.iterator().next();
             try {
                 ClassInitializerRegistry.classInitializer(initializer.newInstance());
-                Logger.debug(String.format("Using %s as class initializer", initializer.getName()));
+                LOGGER.debug("Using {} as class initializer", initializer.getName());
             } catch (InstantiationException e) {
-                Logger.error(String.format("Could not instantiate %s, continuing using default class initializer", initializer.getName()));
+                LOGGER.error("Could not instantiate {}, continuing using default class initializer", initializer.getName());
             } catch (IllegalAccessException e) {
-                Logger.error(String.format("Could not access %s constructor, continuing using default class initializer", initializer.getName()));
+                LOGGER.error("Could not access {} constructor, continuing using default class initializer", initializer.getName());
             }
         }
 
         if (initializers.size() > 1) {
-            Logger.warning("Multiple class initializers found, switching to default.");
+            LOGGER.warn("Multiple class initializers found, switching to default.");
         }
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/scan/HooksScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/scan/HooksScanner.java
@@ -15,8 +15,9 @@ import com.thoughtworks.gauge.BeforeScenario;
 import com.thoughtworks.gauge.BeforeSpec;
 import com.thoughtworks.gauge.BeforeStep;
 import com.thoughtworks.gauge.BeforeSuite;
-import com.thoughtworks.gauge.Logger;
 import com.thoughtworks.gauge.registry.HooksRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.reflections.Reflections;
 
 /**
@@ -24,8 +25,10 @@ import org.reflections.Reflections;
  */
 public class HooksScanner implements IScanner {
 
+    private static final Logger LOGGER = LogManager.getLogger(HooksScanner.class);
+
     public void scan(Reflections reflections) {
-        Logger.debug("Scanning packages for hooks");
+        LOGGER.debug("Scanning packages for hooks");
         buildHooksRegistry(reflections);
     }
 

--- a/src/main/java/com/thoughtworks/gauge/scan/StaticScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/scan/StaticScanner.java
@@ -9,8 +9,10 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.thoughtworks.gauge.FileHelper;
-import com.thoughtworks.gauge.Logger;
+import com.thoughtworks.gauge.GaugeExceptionLogger;
 import com.thoughtworks.gauge.registry.StepRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -26,6 +28,7 @@ import static com.thoughtworks.gauge.GaugeConstant.PACKAGE_TO_SCAN;
 
 public class StaticScanner {
 
+    private static final Logger LOGGER = LogManager.getLogger(StaticScanner.class);
     private final StepRegistry stepRegistry;
 
     public StaticScanner() {
@@ -83,7 +86,7 @@ public class StaticScanner {
             byte[] contents = Files.readAllBytes(Paths.get(path));
             return new String(contents, encoding);
         } catch (IOException e) {
-            Logger.error("Unable to read file", e);
+            GaugeExceptionLogger.error(LOGGER, "Unable to read file", e);
         }
         return null;
     }

--- a/src/main/java/com/thoughtworks/gauge/scan/StepsScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/scan/StepsScanner.java
@@ -5,8 +5,13 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.scan;
 
-import com.thoughtworks.gauge.*;
+import com.thoughtworks.gauge.Step;
+import com.thoughtworks.gauge.StepRegistryEntry;
+import com.thoughtworks.gauge.StepValue;
+import com.thoughtworks.gauge.Util;
 import com.thoughtworks.gauge.registry.StepRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.reflections.Reflections;
 
 import java.lang.reflect.Method;
@@ -17,6 +22,8 @@ import java.util.Set;
  * Scans for step implementations.
  */
 public class StepsScanner implements IScanner {
+
+    private static final Logger LOGGER = LogManager.getLogger(StepsScanner.class);
     private final StepRegistry registry;
 
     public StepsScanner(StepRegistry registry) {
@@ -24,7 +31,7 @@ public class StepsScanner implements IScanner {
     }
 
     public void scan(Reflections reflections) {
-        Logger.debug("Scanning packages for steps");
+        LOGGER.debug("Scanning packages for steps");
         Set<Method> stepImplementations = reflections.getMethodsAnnotatedWith(Step.class);
         buildStepRegistry(stepImplementations);
     }
@@ -40,7 +47,7 @@ public class StepsScanner implements IScanner {
                     if (registry.contains(stepText)) {
                         StepRegistryEntry entry = registry.getForCurrentProject(stepText, method);
                         if (entry != null) {
-                            Logger.debug("Found " + stepText + " in current project scope.");
+                            LOGGER.trace("Found step '{}' in current project scope.", parameterizedStep);
                             entry.setMethodInfo(method);
                         } else {
                             addExternalStepEntryToRegistry(stepsUtil, method, parameterizedStep, stepText);
@@ -54,7 +61,7 @@ public class StepsScanner implements IScanner {
     }
 
     private void addExternalStepEntryToRegistry(StepsUtil stepsUtil, Method method, String parameterizedStep, String stepText) {
-        Logger.debug("Loading " + stepText + "via reflected sources.");
+        LOGGER.trace("Loading step '{}' via reflected sources.", parameterizedStep);
         List<String> parameters = stepsUtil.getParameters(parameterizedStep);
         StepValue stepValue = new StepValue(stepText, parameterizedStep, parameters);
         registry.addStepImplementation(stepValue, method, true);

--- a/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotScanner.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/CustomScreenshotScanner.java
@@ -5,8 +5,9 @@
  *----------------------------------------------------------------*/
 package com.thoughtworks.gauge.screenshot;
 
-import com.thoughtworks.gauge.Logger;
 import com.thoughtworks.gauge.scan.IScanner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.reflections.Reflections;
 
 import java.util.Set;
@@ -15,12 +16,15 @@ import java.util.Set;
  * Scans for a custom screenshot grabber.
  */
 public class CustomScreenshotScanner implements IScanner {
+
+    private static final Logger LOGGER = LogManager.getLogger(CustomScreenshotScanner.class);
+
     public void scan(Reflections reflections) {
         Set<Class<? extends ICustomScreenshotGrabber>> customScreenshotGrabbers = reflections.getSubTypesOf(ICustomScreenshotGrabber.class);
 
         if (customScreenshotGrabbers.size() > 0) {
             Class<? extends ICustomScreenshotGrabber> customScreenGrabber = customScreenshotGrabbers.iterator().next();
-            Logger.debug(String.format("Using %s as custom screenshot grabber", customScreenGrabber.getName()));
+            LOGGER.debug("Using {} as custom screenshot grabber", customScreenGrabber.getName());
             ScreenshotFactory.setCustomScreenshotGrabber(customScreenGrabber);
         }
 
@@ -28,7 +32,7 @@ public class CustomScreenshotScanner implements IScanner {
 
         if (customScreenshotWriters.size() > 0) {
             Class<? extends CustomScreenshotWriter> customScreenWriter = customScreenshotWriters.iterator().next();
-            Logger.debug(String.format("Using %s as custom screenshot grabber", customScreenWriter.getName()));
+            LOGGER.debug("Using {} as custom screenshot grabber", customScreenWriter.getName());
             ScreenshotFactory.setCustomScreenshotGrabber(customScreenWriter);
         }
     }

--- a/src/main/java/com/thoughtworks/gauge/screenshot/ScreenshotFactory.java
+++ b/src/main/java/com/thoughtworks/gauge/screenshot/ScreenshotFactory.java
@@ -7,7 +7,8 @@ package com.thoughtworks.gauge.screenshot;
 
 import com.thoughtworks.gauge.ClassInstanceManager;
 import com.thoughtworks.gauge.GaugeConstant;
-import com.thoughtworks.gauge.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.imageio.ImageIO;
 import java.awt.GraphicsDevice;
@@ -25,6 +26,8 @@ import java.util.UUID;
  * Used to take screenshots on failure.
  */
 public class ScreenshotFactory {
+
+    private static final Logger LOGGER = LogManager.getLogger(ScreenshotFactory.class);
 
     public static final String IMAGE_EXTENSION = "png";
     private static Class<? extends CustomScreenshot> customScreenshotGrabber;
@@ -57,8 +60,8 @@ public class ScreenshotFactory {
                     return file.getName();
                 }
             } catch (Exception e) {
-                Logger.error(String.format("Failed to take Custom screenshot: %s : %s", customScreenshotGrabber.getCanonicalName(), e.getMessage()));
-                Logger.warning("Capturing regular screenshot..");
+                LOGGER.error("Failed to take Custom screenshot: {} : {}", customScreenshotGrabber.getCanonicalName(), e.getMessage());
+                LOGGER.warn("Capturing regular screenshot..");
             }
         }
         return captureScreen();
@@ -81,7 +84,7 @@ public class ScreenshotFactory {
             BufferedImage image = new Robot().createScreenCapture(screenRect);
             ImageIO.write(image, IMAGE_EXTENSION, file);
         } catch (Throwable e) {
-            Logger.error("Failed to take regular screenshot: " + e.getMessage());
+            LOGGER.error("Failed to take regular screenshot: {}", e.getMessage());
         }
         return file.getName();
     }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %level %logger{36} %method - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="ALL">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR switches logging from using system out to using log4j2 loggers. It also changes the log format away from using json objects to a more standard format by default. If this is an issue, the default format can be changed using the log4j2.xml file. This PR also deprecates the Logger class and adds an GaugeExceptionLogger class to handle logging exceptions and fatal level logging.

This will allow users of this plugin to have more control over its logs and know where logs are actually coming from. This is specifically beneficial in situations where its logs are consumed by Splunk.

I have bumped the version from 0.11.2 to 0.12.0 as this is a significant change.
