### PR TITLE
Override slf4j-api version

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
             <version>3.27.3</version>
         </dependency>
         <dependency>
+            <!-- The reflections library pulls in version 1.7.36. This overrides it to be 2.0.16 to allow downstream applications to use log4j2-->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.16</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>0.11.3</version>
+    <version>0.11.4</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>
@@ -39,9 +39,20 @@
             <version>3.27.3</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.16</version>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>


### PR DESCRIPTION
Currently, the Reflections library pulls in slf4j-api 1.7.36. This means applications using the gauge-java plugin are unable to use log4j2 without dealing with dependency conflicts. Given that the Reflections library is no longer maintained, I suggest we override the slf4j-api version to 2.0.16