### PR TITLE
feat: add support for skipping scenarios via SkipScenarioException

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>0.11.4</version>
+    <version>0.11.5</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>0.11.5</version>
+    <version>0.12.0</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>

--- a/src/main/java/com/thoughtworks/gauge/SkipScenarioException.java
+++ b/src/main/java/com/thoughtworks/gauge/SkipScenarioException.java
@@ -1,7 +1,12 @@
-  package com.thoughtworks.gauge;
+package com.thoughtworks.gauge;
 
-  public class SkipScenarioException extends RuntimeException {
+public class SkipScenarioException extends RuntimeException {
     public SkipScenarioException(String message) {
-      super(message);
+        super(message);
     }
-  }
+
+    @SuppressWarnings("unused")
+    public SkipScenarioException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/thoughtworks/gauge/SkipScenarioException.java
+++ b/src/main/java/com/thoughtworks/gauge/SkipScenarioException.java
@@ -1,0 +1,7 @@
+  package com.thoughtworks.gauge;
+
+  public class SkipScenarioException extends RuntimeException {
+    public SkipScenarioException(String message) {
+      super(message);
+    }
+  }

--- a/src/main/java/com/thoughtworks/gauge/execution/AbstractExecutionStage.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/AbstractExecutionStage.java
@@ -20,10 +20,12 @@ public abstract class AbstractExecutionStage implements ExecutionStage {
     protected Spec.ProtoExecutionResult mergeExecResults(Spec.ProtoExecutionResult previousStageResult, Spec.ProtoExecutionResult execResult) {
         long execTime = execResult.getExecutionTime() + previousStageResult.getExecutionTime();
         boolean failed = execResult.getFailed() | previousStageResult.getFailed();
+        boolean skipped = execResult.getSkipScenario() | previousStageResult.getSkipScenario() ;
 
         Spec.ProtoExecutionResult.Builder builder = Spec.ProtoExecutionResult.newBuilder();
         builder.setExecutionTime(execTime);
         builder.setFailed(failed);
+        builder.setSkipScenario(skipped);
         if (previousStageResult.getFailed()) {
             builder.setErrorMessage(previousStageResult.getErrorMessage());
             builder.setErrorType(previousStageResult.getErrorType());

--- a/src/main/java/com/thoughtworks/gauge/execution/AbstractExecutionStage.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/AbstractExecutionStage.java
@@ -20,7 +20,7 @@ public abstract class AbstractExecutionStage implements ExecutionStage {
     protected Spec.ProtoExecutionResult mergeExecResults(Spec.ProtoExecutionResult previousStageResult, Spec.ProtoExecutionResult execResult) {
         long execTime = execResult.getExecutionTime() + previousStageResult.getExecutionTime();
         boolean failed = execResult.getFailed() | previousStageResult.getFailed();
-        boolean skipped = execResult.getSkipScenario() | previousStageResult.getSkipScenario() ;
+        boolean skipped = execResult.getSkipScenario() | previousStageResult.getSkipScenario();
 
         Spec.ProtoExecutionResult.Builder builder = Spec.ProtoExecutionResult.newBuilder();
         builder.setExecutionTime(execTime);

--- a/src/main/java/com/thoughtworks/gauge/execution/MethodExecutor.java
+++ b/src/main/java/com/thoughtworks/gauge/execution/MethodExecutor.java
@@ -15,7 +15,7 @@ import gauge.messages.Spec;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
-import java.util.Set;
+import java.util.Optional;
 
 public class MethodExecutor {
     private final ClassInstanceManager instanceManager;
@@ -32,28 +32,29 @@ public class MethodExecutor {
             long endTime = System.currentTimeMillis();
             return Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(endTime - startTime).build();
         } catch (Throwable e) {
+            long execTime = System.currentTimeMillis() - startTime;
 
-            Throwable actualException = (e.getCause() != null) ? e.getCause() : e;
+            if (e.getCause() instanceof SkipScenarioException) {
+                return createSkippedExecResult(execTime, (SkipScenarioException) e.getCause());
+            }
 
-            if (actualException instanceof SkipScenarioException) {
-                long endTime = System.currentTimeMillis();
-                return Spec.ProtoExecutionResult.newBuilder()
-                        .setSkipScenario(true)
-                        .addMessage("SKIPPED: " + actualException.getMessage())
-                        .setExecutionTime(endTime - startTime)
-                        .build();
-            }
-            boolean recoverable = method.isAnnotationPresent(ContinueOnFailure.class);
-            Class[] continuableExceptions = new Class[]{};
-            if (recoverable) {
-                continuableExceptions = method.getAnnotation(ContinueOnFailure.class).value();
-            }
-            long endTime = System.currentTimeMillis();
-            return createFailureExecResult(endTime - startTime, e, recoverable, continuableExceptions);
+            Class<?>[] continuableExceptions = Optional.ofNullable(method.getAnnotation(ContinueOnFailure.class))
+                    .map(ContinueOnFailure::value).
+                    orElseGet(() -> new Class<?>[]{});
+
+            return createFailureExecResult(execTime, e, method.isAnnotationPresent(ContinueOnFailure.class), continuableExceptions);
         }
     }
 
-    private Spec.ProtoExecutionResult createFailureExecResult(long execTime, Throwable e, boolean recoverable, Class[] continuableExceptions) {
+    private Spec.ProtoExecutionResult createSkippedExecResult(long execTime, SkipScenarioException cause) {
+        return Spec.ProtoExecutionResult.newBuilder()
+                .setSkipScenario(true)
+                .addMessage(Optional.ofNullable(cause.getMessage()).orElse("SKIPPED"))
+                .setExecutionTime(execTime)
+                .build();
+    }
+
+    private Spec.ProtoExecutionResult createFailureExecResult(long execTime, Throwable e, boolean recoverable, Class<?>[] continuableExceptions) {
         Spec.ProtoExecutionResult.Builder builder = Spec.ProtoExecutionResult.newBuilder().setFailed(true);
         if (Util.shouldTakeFailureScreenshot()) {
             String screenshotFileName = new ScreenshotFactory(instanceManager).getScreenshotBytes();
@@ -61,7 +62,7 @@ public class MethodExecutor {
         }
         if (e.getCause() != null) {
             builder.setRecoverableError(false);
-            for (Class c : continuableExceptions) {
+            for (Class<?> c : continuableExceptions) {
                 if (c.isAssignableFrom(e.getCause().getClass()) && recoverable) {
                     builder.setRecoverableError(true);
                     break;
@@ -85,17 +86,5 @@ public class MethodExecutor {
         StringWriter out = new StringWriter();
         t.printStackTrace(new PrintWriter(out));
         return out.toString();
-    }
-
-    public Spec.ProtoExecutionResult executeMethods(Set<Method> methods, Object... args) {
-        long totalExecutionTime = 0;
-        for (Method method : methods) {
-            Spec.ProtoExecutionResult result = execute(method, args);
-            totalExecutionTime += result.getExecutionTime();
-            if (result.getFailed()) {
-                return result;
-            }
-        }
-        return Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(totalExecutionTime).build();
     }
 }

--- a/src/test/java/com/thoughtworks/gauge/execution/AbstractExecutionStageTest.java
+++ b/src/test/java/com/thoughtworks/gauge/execution/AbstractExecutionStageTest.java
@@ -6,6 +6,7 @@
 package com.thoughtworks.gauge.execution;
 
 import gauge.messages.Spec;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,94 +22,141 @@ public class AbstractExecutionStageTest {
         assertEquals(2100, result.getExecutionTime());
     }
 
-    @Test
-    public void testMergingResultsPreviousFailing() throws Exception {
-        String screenShot = "1";
+    @Nested
+    public class Failing {
 
-        Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
-                setExecutionTime(100).
-                setRecoverableError(false).
-                setErrorMessage("Previous failed").
-                setStackTrace("Previous stacktrace").
-                setFailureScreenshotFile(screenShot).build();
-        Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(1100).build();
-        Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+        @Test
+        public void testMergingResultsPreviousFailing() throws Exception {
+            String screenShot = "1";
 
-        assertTrue(result.getFailed());
-        assertEquals(1200, result.getExecutionTime());
-        assertEquals("Previous failed", result.getErrorMessage());
-        assertEquals("Previous stacktrace", result.getStackTrace());
-        assertFalse(result.getRecoverableError());
-        assertEquals(screenShot, result.getFailureScreenshotFile());
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(true)
+                    .setExecutionTime(100)
+                    .setRecoverableError(false)
+                    .setErrorMessage("Previous failed")
+                    .setStackTrace("Previous stacktrace")
+                    .setFailureScreenshotFile(screenShot).build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(1100).build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+
+            assertTrue(result.getFailed());
+            assertEquals(1200, result.getExecutionTime());
+            assertEquals("Previous failed", result.getErrorMessage());
+            assertEquals("Previous stacktrace", result.getStackTrace());
+            assertFalse(result.getRecoverableError());
+            assertEquals(screenShot, result.getFailureScreenshotFile());
+        }
+
+        @Test
+        public void testMergingResultsCurrentFailing() throws Exception {
+            String screenShot = "2";
+
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(100).build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true)
+                    .setExecutionTime(100)
+                    .setRecoverableError(false)
+                    .setErrorMessage("current failed")
+                    .setStackTrace("current stacktrace")
+                    .setFailureScreenshotFile(screenShot).build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+
+            assertTrue(result.getFailed());
+            assertEquals(200, result.getExecutionTime());
+            assertEquals("current failed", result.getErrorMessage());
+            assertEquals("current stacktrace", result.getStackTrace());
+            assertFalse(result.getRecoverableError());
+            assertEquals(screenShot, result.getFailureScreenshotFile());
+        }
+
+        @Test
+        public void testMergingResultsBothFailing() throws Exception {
+            String screenShotPrevious = "2";
+            String screenShotCurrent = "hello";
+
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(true)
+                    .setExecutionTime(1001)
+                    .setRecoverableError(true)
+                    .setErrorMessage("previous failed")
+                    .setStackTrace("previous stacktrace")
+                    .setFailureScreenshotFile(screenShotPrevious).build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true)
+                    .setExecutionTime(1002)
+                    .setRecoverableError(false)
+                    .setErrorMessage("current failed")
+                    .setStackTrace("current stacktrace")
+                    .setFailureScreenshotFile(screenShotCurrent).build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+
+            assertTrue(result.getFailed());
+            assertEquals(2003, result.getExecutionTime());
+            assertEquals("previous failed", result.getErrorMessage());
+            assertEquals("previous stacktrace", result.getStackTrace());
+            assertFalse(result.getRecoverableError());
+            assertEquals(screenShotPrevious, result.getFailureScreenshotFile());
+        }
+
+        @Test
+        public void testMergingResultsCurrentFailingAndIsRecoverable() throws Exception {
+            String screenShotCurrent = "screenShotCurrent.png";
+
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(1001).build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true)
+                    .setExecutionTime(1002)
+                    .setRecoverableError(true)
+                    .setErrorMessage("current failed")
+                    .setStackTrace("current stacktrace")
+                    .setFailureScreenshotFile(screenShotCurrent).build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+
+            assertTrue(result.getFailed());
+            assertEquals(2003, result.getExecutionTime());
+            assertEquals("current failed", result.getErrorMessage());
+            assertEquals("current stacktrace", result.getStackTrace());
+            assertTrue(result.getRecoverableError());
+            assertEquals(screenShotCurrent, result.getFailureScreenshotFile());
+        }
     }
 
-    @Test
-    public void testMergingResultsCurrentFailing() throws Exception {
-        String screenShot = "2";
+    @Nested
+    public class Skipped {
 
-        Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(100).build();
-        Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
-                setExecutionTime(100).
-                setRecoverableError(false).
-                setErrorMessage("current failed").
-                setStackTrace("current stacktrace").
-                setFailureScreenshotFile(screenShot).build();
-        Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+        @Test
+        public void testMergingResultsPreviousSkipped() throws Exception {
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setSkipScenario(true)
+                    .setExecutionTime(100)
+                    .build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setSkipScenario(false).setExecutionTime(1100).build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
-        assertTrue(result.getFailed());
-        assertEquals(200, result.getExecutionTime());
-        assertEquals("current failed", result.getErrorMessage());
-        assertEquals("current stacktrace", result.getStackTrace());
-        assertFalse(result.getRecoverableError());
-        assertEquals(screenShot, result.getFailureScreenshotFile());
-    }
+            assertTrue(result.getSkipScenario());
+            assertEquals(1200, result.getExecutionTime());
+        }
 
-    @Test
-    public void testMergingResultsBothFailing() throws Exception {
-        String screenShotPrevious = "2";
-        String screenShotCurrent = "hello";
+        @Test
+        public void testMergingResultsCurrentSkipped() throws Exception {
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setSkipScenario(false).setExecutionTime(100).build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setSkipScenario(true)
+                    .setExecutionTime(100)
+                    .build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
-        Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
-                setExecutionTime(1001).
-                setRecoverableError(true).
-                setErrorMessage("previous failed").
-                setStackTrace("previous stacktrace").
-                setFailureScreenshotFile(screenShotPrevious).build();
-        Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
-                setExecutionTime(1002).
-                setRecoverableError(false).
-                setErrorMessage("current failed").
-                setStackTrace("current stacktrace").
-                setFailureScreenshotFile(screenShotCurrent).build();
-        Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
+            assertTrue(result.getSkipScenario());
+            assertEquals(200, result.getExecutionTime());
+        }
 
-        assertTrue(result.getFailed());
-        assertEquals(2003, result.getExecutionTime());
-        assertEquals("previous failed", result.getErrorMessage());
-        assertEquals("previous stacktrace", result.getStackTrace());
-        assertFalse(result.getRecoverableError());
-        assertEquals(screenShotPrevious, result.getFailureScreenshotFile());
-    }
+        @Test
+        public void testMergingResultsBothSkipped() throws Exception {
+            Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setSkipScenario(true)
+                    .setExecutionTime(1001)
+                    .build();
+            Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setSkipScenario(true)
+                    .setExecutionTime(1002)
+                    .build();
+            Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
 
-    @Test
-    public void testMergingResultsCurrentFailingAndIsRecoverable() throws Exception {
-        String screenShotCurrent = "screenShotCurrent.png";
+            assertTrue(result.getSkipScenario());
+            assertEquals(2003, result.getExecutionTime());
+        }
 
-        Spec.ProtoExecutionResult previous = Spec.ProtoExecutionResult.newBuilder().setFailed(false).setExecutionTime(1001).build();
-        Spec.ProtoExecutionResult current = Spec.ProtoExecutionResult.newBuilder().setFailed(true).
-                setExecutionTime(1002).
-                setRecoverableError(true).
-                setErrorMessage("current failed").
-                setStackTrace("current stacktrace").
-                setFailureScreenshotFile(screenShotCurrent).build();
-        Spec.ProtoExecutionResult result = new TestExecutionStage().mergeExecResults(previous, current);
-
-        assertTrue(result.getFailed());
-        assertEquals(2003, result.getExecutionTime());
-        assertEquals("current failed", result.getErrorMessage());
-        assertEquals("current stacktrace", result.getStackTrace());
-        assertTrue(result.getRecoverableError());
-        assertEquals(screenShotCurrent, result.getFailureScreenshotFile());
     }
 
     private static class TestExecutionStage extends AbstractExecutionStage {

--- a/src/test/java/com/thoughtworks/gauge/execution/StepExecutionStageTest.java
+++ b/src/test/java/com/thoughtworks/gauge/execution/StepExecutionStageTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -202,8 +203,7 @@ public class StepExecutionStageTest {
 
         assertFalse(result.getFailed());
         assertTrue(result.getSkipScenario());
-        assertTrue(result.getMessageList().get(0).startsWith("SKIPPED:"));
-        assertTrue(result.getMessageList().get(0).contains("skipping this scenario"));
+        assertThat(result.getMessageList()).containsExactly("skipping this scenario due to unmet condition");
     }
 
     @ContinueOnFailure


### PR DESCRIPTION
## Overview

This PR addresses [issue #691](https://github.com/getgauge/gauge-java/issues/691) by introducing native support for skipping scenarios

### 🔧 Changes Made

- ✅ Introduced `SkipScenarioException`, which can be thrown to trigger a skip.
- ✅ Updated `MethodExecutor` to catch `SkipScenarioException`, mark the step as `skipScenario = true`, and prevent it from failing.
- ✅ Included `SKIPPED: <reason>` messages in the execution result.
- ✅ Extended `StepExecutionStageTest` with a new test: `testStepMethodExecutionWithSkipScenarioException`.


