### PR TITLE
Bump version to 1.0.2 and update JUnit dependency to 6.1.2

### DIFF
--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/java.json
+++ b/java.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Java support for gauge",
   "install": {
     "windows": [],

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>1.1.0</version>
+    <version>1.0.2</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>gauge-java</name>
     <groupId>com.thoughtworks.gauge</groupId>
     <artifactId>gauge-java</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <description>Java plugin for Gauge</description>
     <url>https://github.com/getgauge/gauge-java</url>
     <dependencyManagement>
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>6.1.1</version>
+                <version>6.1.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This pull request updates the Java plugin for Gauge to a new minor version and bumps a JUnit dependency. The changes are primarily focused on version management to ensure compatibility and access to the latest features and fixes.

Version updates:

* Updated the plugin version from `1.0.1` to `1.1.0` in both `java.json` and `pom.xml` to reflect a new release. [[1]](diffhunk://#diff-acc28769fc1529d6a8a3462f874e725e8e447626096ba6946a7bf56c4c93fb36L3-R3) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7)

Dependency updates:

* Upgraded the `junit-bom` dependency version from `6.1.1` to `6.1.2` in `pom.xml` for improved stability and bug fixes.